### PR TITLE
Adding dCSFA-NMF and nmf_base_class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Code for preprocessing and building models with local field potentials.
 
+<p align="center">
+<a href="https://github.com/psf/black/blob/main/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
+<a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+</p>
+
 See `feature_pipeline.py` and `prediction_pipeline.py` for usage.
 
 <p align="center">
@@ -22,8 +27,9 @@ $ make html # build docs
 Then see `docs/build/html/index.html` for the docs.
 
 #### Dependencies
-* [Python3](https://www.python.org/)
+* [Python3](https://www.python.org/) (3.7+)
 * [PyTorch](https://pytorch.org) 1.11+
+* [Black](https://github.com/psf/black)
 * [MoviePy](https://github.com/Zulko/moviepy) (optional)
 
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-## LPNE feature extraction and classification pipeline
+<h1 align="center">LPNE feature extraction and classification pipeline</h1>
 
-Code for preprocessing and building models with local field potentials.
+<h2 align="center">Code for preprocessing and building models with local field potentials</h2>
+
 
 <p align="center">
-<a href="https://github.com/psf/black/blob/main/LICENSE"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
+<a href="https://github.com/carlson-lab/lpne/blob/master/LICENSE.md"><img alt="License: MIT" src="https://black.readthedocs.io/en/stable/_static/license.svg"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
 </p>
 

--- a/apps/feature_app/main.py
+++ b/apps/feature_app/main.py
@@ -6,9 +6,20 @@ __date__ = "December 2021 - August 2022"
 
 
 from bokeh.layouts import column, row
-from bokeh.models import Button, CheckboxGroup, ColumnDataSource, Select, \
-        Panel, PreText, Slider, Tabs, TextInput, MultiSelect, DataTable, \
-        TableColumn
+from bokeh.models import (
+    Button,
+    CheckboxGroup,
+    ColumnDataSource,
+    Select,
+    Panel,
+    PreText,
+    Slider,
+    Tabs,
+    TextInput,
+    MultiSelect,
+    DataTable,
+    TableColumn,
+)
 from bokeh.plotting import curdoc
 import numpy as np
 from itertools import repeat
@@ -23,12 +34,12 @@ BUTTON_SIZE = 150
 TEXT_INPUT_WIDTH = 500
 MULTISELECT_HEIGHT = 500
 MULTISELECT_WIDTH = 350
-DEFAULT_LFP_DIR = '/Users/jack/Desktop/lpne/test_data/Data/'
-DEFAULT_CHANS_DIR = '/Users/jack/Desktop/lpne/test_data/CHANS/'
-DEFAULT_FEATURE_DIR = '/Users/jack/Desktop/lpne/test_data/features/'
+DEFAULT_LFP_DIR = "/Users/jack/Desktop/lpne/test_data/Data/"
+DEFAULT_CHANS_DIR = "/Users/jack/Desktop/lpne/test_data/CHANS/"
+DEFAULT_FEATURE_DIR = "/Users/jack/Desktop/lpne/test_data/features/"
 DEFAULT_DURATION = 2
 NULL_SELECTION = "No selection"
-LFP_SUFFIX = '_LFP.mat'
+LFP_SUFFIX = "_LFP.mat"
 
 # FILTERING
 LFP_LOWCUT = 0.5
@@ -37,10 +48,9 @@ Q = 1.5
 
 # CHANNEL MAP
 DEFAULT_MAP = dict(
-        channel_names=['foo', 'bar'],
-        roi_names=['foo', 'bar'],
+    channel_names=["foo", "bar"],
+    roi_names=["foo", "bar"],
 )
-
 
 
 def feature_app(doc):
@@ -56,11 +66,11 @@ def feature_app(doc):
         TableColumn(field="roi_names", title="ROI Name"),
     ]
     data_table = DataTable(
-            source=source,
-            columns=columns,
-            width=500,
-            height=400,
-            editable=True,
+        source=source,
+        columns=columns,
+        width=500,
+        height=400,
+        editable=True,
     )
 
     channel_map_button = Button(label="Populate with Defaults", default_size=200)
@@ -69,27 +79,27 @@ def feature_app(doc):
         lfp_dir = lfp_dir_input.value
         if not os.path.exists(lfp_dir):
             alert_box.text = f"LFP directory does not exist: {lfp_dir}"
-            channel_map_button.button_type="warning"
+            channel_map_button.button_type = "warning"
             return
         combine_hemi = 0 in hemisphere_checkbox.active
-        lfp_fns = sorted([os.path.join(lfp_dir,i) for i in multi_select_1.value])
+        lfp_fns = sorted([os.path.join(lfp_dir, i) for i in multi_select_1.value])
         if len(lfp_fns) == 0:
             alert_box.text = f"No LFP filenames selected!"
-            channel_map_button.button_type="warning"
+            channel_map_button.button_type = "warning"
             return
         all_keys = []
         for file_num in range(len(lfp_fns)):
             if not os.path.exists(lfp_fns[file_num]):
                 alert_box.text = f"LFP filename does not exist: {lfp_fns[file_num]}"
-                channel_map_button.button_type="warning"
+                channel_map_button.button_type = "warning"
                 return
             # Load LFP data.
             lfps = lpne.load_lfps(lfp_fns[file_num])
             all_keys.append(list(lfps.keys()))
         all_keys = np.unique(all_keys)
         channel_map = lpne.get_default_channel_map(
-                all_keys,
-                combine_hemispheres=combine_hemi,
+            all_keys,
+            combine_hemispheres=combine_hemi,
         )
         new_data = dict(
             channel_names=list(channel_map.keys()),
@@ -99,14 +109,11 @@ def feature_app(doc):
         channel_map_button.button_type = "default"
         alert_box.text = ""
 
-
     channel_map_button.on_click(channel_map_callback)
-
 
     ###################
     # Input data tab. #
     ###################
-
 
     if os.path.exists(DEFAULT_LFP_DIR):
         initial_options = _my_listdir(DEFAULT_LFP_DIR)
@@ -114,16 +121,15 @@ def feature_app(doc):
         initial_options = []
 
     multi_select_1 = MultiSelect(
-            value=[],
-            options=initial_options,
-            title="Select LFP files:",
-            height=MULTISELECT_HEIGHT,
-            width=MULTISELECT_WIDTH,
+        value=[],
+        options=initial_options,
+        title="Select LFP files:",
+        height=MULTISELECT_HEIGHT,
+        width=MULTISELECT_WIDTH,
     )
 
     def update_multi_select_1(new_options):
         multi_select_1.options = new_options
-
 
     if os.path.exists(DEFAULT_CHANS_DIR):
         initial_options = _my_listdir(DEFAULT_CHANS_DIR)
@@ -131,16 +137,15 @@ def feature_app(doc):
         initial_options = []
 
     multi_select_2 = MultiSelect(
-            value=[],
-            options=initial_options,
-            title="Select CHANS file or files:",
-            height=MULTISELECT_HEIGHT,
-            width=MULTISELECT_WIDTH,
+        value=[],
+        options=initial_options,
+        title="Select CHANS file or files:",
+        height=MULTISELECT_HEIGHT,
+        width=MULTISELECT_WIDTH,
     )
 
     def update_multi_select_2(new_options):
         multi_select_2.options = new_options
-
 
     def lfp_dir_input_callback(attr, old, new):
         """If the directory exists, populate the file selector."""
@@ -150,8 +155,8 @@ def feature_app(doc):
                 load_dir = load_dir[:-1]
             if len(load_dir.split(os.path.sep)) > 1:
                 save_dir = load_dir.split(os.path.sep)[:-1]
-                save_dir.append('features')
-                save_dir.append(str(window_slider.value)+'s')
+                save_dir.append("features")
+                save_dir.append(str(window_slider.value) + "s")
                 save_dir_input.value = os.path.sep + os.path.join(*save_dir)
             update_multi_select_1(_my_listdir(load_dir))
             alert_box.text = ""
@@ -159,12 +164,11 @@ def feature_app(doc):
             alert_box.text = f"Not a valid directory: {new}"
 
     lfp_dir_input = TextInput(
-            value=DEFAULT_LFP_DIR,
-            title="Enter LFP directory:",
-            width=TEXT_INPUT_WIDTH,
+        value=DEFAULT_LFP_DIR,
+        title="Enter LFP directory:",
+        width=TEXT_INPUT_WIDTH,
     )
     lfp_dir_input.on_change("value", lfp_dir_input_callback)
-
 
     def chans_dir_input_callback(attr, old, new):
         """If the directory exists, populate the file selector."""
@@ -175,19 +179,18 @@ def feature_app(doc):
             alert_box.text = f"Not a valid directory: {new}"
 
     chans_dir_input = TextInput(
-            value=DEFAULT_CHANS_DIR,
-            title="Enter CHANS directory:",
-            width=TEXT_INPUT_WIDTH,
+        value=DEFAULT_CHANS_DIR,
+        title="Enter CHANS directory:",
+        width=TEXT_INPUT_WIDTH,
     )
     chans_dir_input.on_change("value", chans_dir_input_callback)
 
-
     window_slider = Slider(
-            start=1,
-            end=20,
-            value=DEFAULT_DURATION,
-            step=1,
-            title="Window duration (s)",
+        start=1,
+        end=20,
+        value=DEFAULT_DURATION,
+        step=1,
+        title="Window duration (s)",
     )
 
     def window_slider_callback(attr, old, new):
@@ -196,8 +199,8 @@ def feature_app(doc):
             load_dir = load_dir[:-1]
         if os.path.exists(load_dir) and len(load_dir.split(os.path.sep)) > 1:
             save_dir = load_dir.split(os.path.sep)[:-1]
-            save_dir.append('features')
-            save_dir.append(str(window_slider.value)+'s')
+            save_dir.append("features")
+            save_dir.append(str(window_slider.value) + "s")
             save_dir_input.value = os.path.sep + os.path.join(*save_dir)
 
     window_slider.on_change("value", window_slider_callback)
@@ -210,35 +213,34 @@ def feature_app(doc):
     # Save tab. #
     #############
     overwrite_checkbox = CheckboxGroup(
-            labels=["Overwrite existing files?"],
-            active=[],
+        labels=["Overwrite existing files?"],
+        active=[],
     )
 
     outlier_checkbox = CheckboxGroup(
-            labels=["Remove outliers?"],
-            active=[0],
+        labels=["Remove outliers?"],
+        active=[0],
     )
 
     hemisphere_checkbox = CheckboxGroup(
-            labels=["Combine hemispheres?"],
-            active=[0],
+        labels=["Combine hemispheres?"],
+        active=[0],
     )
 
     dir_spec_checkbox = CheckboxGroup(
-            labels=["Calculate directed features too?"],
-            active=[],
+        labels=["Calculate directed features too?"],
+        active=[],
     )
 
     channel_map_checkbox = CheckboxGroup(
-            labels=["Use default ROIs?"],
-            active=[],
+        labels=["Use default ROIs?"],
+        active=[],
     )
 
     save_dir_input = TextInput(
-            value=DEFAULT_FEATURE_DIR,
-            title="Enter feature directory:",
+        value=DEFAULT_FEATURE_DIR,
+        title="Enter feature directory:",
     )
-
 
     reset_save_button = Button(label="Reset Save Button", default_size=200)
 
@@ -255,17 +257,17 @@ def feature_app(doc):
         lfp_dir = lfp_dir_input.value
         if not os.path.exists(lfp_dir):
             alert_box.text = f"LFP directory does not exist: {lfp_dir}"
-            save_button.button_type="warning"
+            save_button.button_type = "warning"
             return
         chans_dir = chans_dir_input.value
         if not os.path.exists(chans_dir):
             alert_box.text = f"CHANS directory does not exist: {chans_dir}"
-            save_button.button_type="warning"
+            save_button.button_type = "warning"
             return
         feature_dir = save_dir_input.value
         if not os.path.exists(feature_dir):
             alert_box.text = f"Directory does not exist: {feature_dir}"
-            save_button.button_type="warning"
+            save_button.button_type = "warning"
             return
         window_duration = window_slider.value
         combine_hemi = 0 in hemisphere_checkbox.active
@@ -275,21 +277,21 @@ def feature_app(doc):
         default_channel_map = 0 in channel_map_checkbox.active
         # Get the filenames.
         saved_channels = {}
-        chans_fns = sorted([os.path.join(chans_dir,i) for i in multi_select_2.value])
-        lfp_fns = sorted([os.path.join(lfp_dir,i) for i in multi_select_1.value])
+        chans_fns = sorted([os.path.join(chans_dir, i) for i in multi_select_2.value])
+        lfp_fns = sorted([os.path.join(lfp_dir, i) for i in multi_select_1.value])
         if len(chans_fns) > 1 and len(chans_fns) != len(lfp_fns):
             alert_box.text = f"Unequal number of CHANS and LFP files: {len(chans_fns)} {len(lfp_fns)}"
-            save_button.button_type="warning"
+            save_button.button_type = "warning"
             return
         elif len(chans_fns) == 1:
             chans_fns = chans_fns * len(lfp_fns)
         if len(lfp_fns) == 0:
             alert_box.text = f"No LFP filenames selected!"
-            save_button.button_type="warning"
+            save_button.button_type = "warning"
             return
         if len(chans_fns) == 0:
             alert_box.text = f"No CHANS filenames selected!"
-            save_button.button_type="warning"
+            save_button.button_type = "warning"
             return
         for file_num in range(len(lfp_fns)):
             # Load LFP data.
@@ -299,16 +301,16 @@ def feature_app(doc):
 
             # Remove the bad channels marked in the CHANS file.
             lfps = lpne.remove_channels_from_lfps(lfps, chans_fns[file_num])
-            
+
             # Mark outliers with NaNs.
             if mark_outliers:
                 lfps = lpne.mark_outliers(lfps, int(fs_input.value))
 
                 # Print outlier summary.
                 msg = lpne.get_outlier_summary(
-                        lfps,
-                        int(fs_input.value),
-                        window_duration,
+                    lfps,
+                    int(fs_input.value),
+                    window_duration,
                 )
                 print(lfp_fns[file_num])
                 print(msg)
@@ -316,53 +318,55 @@ def feature_app(doc):
             # Get the default channel grouping.
             if default_channel_map:
                 channel_map = lpne.get_default_channel_map(
-                        list(lfps.keys()),
-                        combine_hemispheres=combine_hemi,
+                    list(lfps.keys()),
+                    combine_hemispheres=combine_hemi,
                 )
             else:
-                channel_map = dict(zip(
+                channel_map = dict(
+                    zip(
                         source.data["channel_names"],
                         source.data["roi_names"],
-                ))
+                    )
+                )
             # Average channels in the same region together.
             lfps = lpne.average_channels(lfps, channel_map)
-            saved_channels = {**saved_channels, **dict(zip(lfps.keys(),repeat(0)))}
-            
+            saved_channels = {**saved_channels, **dict(zip(lfps.keys(), repeat(0)))}
+
             # Make features.
             features = lpne.make_features(
-                    lfps,
-                    window_duration=window_duration,
-                    directed_spectrum=directed_spectrum,
+                lfps,
+                window_duration=window_duration,
+                directed_spectrum=directed_spectrum,
             )
-            
+
             # Save features.
-            fn = os.path.split(lfp_fns[file_num])[-1][:-len(LFP_SUFFIX)] + '.npy'
+            fn = os.path.split(lfp_fns[file_num])[-1][: -len(LFP_SUFFIX)] + ".npy"
             fn = os.path.join(feature_dir, fn)
             if not overwrite and os.path.exists(fn):
                 alert_box.text = f"File already exists: {fn}"
-                save_button.button_type="warning"
+                save_button.button_type = "warning"
                 return
             lpne.save_features(features, fn)
         save_button.label = "Saved"
-        save_button.button_type="success"
+        save_button.button_type = "success"
         alert_box.text = f"Saved channels: {list(saved_channels.keys())}"
 
     save_button.on_click(save_callback)
 
     column_1 = column(
-            lfp_dir_input,
-            chans_dir_input,
-            fs_input,
-            window_slider,
-            save_dir_input,
-            hemisphere_checkbox,
-            outlier_checkbox,
-            dir_spec_checkbox,
-            overwrite_checkbox,
-            channel_map_checkbox,
-            save_button,
-            reset_save_button,
-            alert_box,
+        lfp_dir_input,
+        chans_dir_input,
+        fs_input,
+        window_slider,
+        save_dir_input,
+        hemisphere_checkbox,
+        outlier_checkbox,
+        dir_spec_checkbox,
+        overwrite_checkbox,
+        channel_map_checkbox,
+        save_button,
+        reset_save_button,
+        alert_box,
     )
     column_2 = column(multi_select_1, multi_select_2)
     tab_1 = Panel(
@@ -381,9 +385,9 @@ def feature_app(doc):
 
 
 def _my_listdir(dir):
-    if dir == '':
+    if dir == "":
         return []
-    return sorted([i for i in os.listdir(dir) if not i.startswith('.')])
+    return sorted([i for i in os.listdir(dir) if not i.startswith(".")])
 
 
 # Run the app.

--- a/apps/label_editing_app/main.py
+++ b/apps/label_editing_app/main.py
@@ -6,8 +6,17 @@ __date__ = "September - October 2021"
 
 
 from bokeh.layouts import column, row
-from bokeh.models import Button, CheckboxGroup, ColumnDataSource, Select, \
-        Panel, PreText, Slider, Tabs, TextInput
+from bokeh.models import (
+    Button,
+    CheckboxGroup,
+    ColumnDataSource,
+    Select,
+    Panel,
+    PreText,
+    Slider,
+    Tabs,
+    TextInput,
+)
 from bokeh.plotting import figure, curdoc
 from matplotlib.colors import to_hex
 import numpy as np
@@ -22,17 +31,17 @@ SCATTER_SIZE = 16
 LINE_WIDTH = 1
 LFP_HEIGHT = 220
 LFP_WIDTH = 1000
-DEFAULT_LFP_DIR = '/Users/jack/Desktop/lpne/test_data/Data/'
-DEFAULT_LABEL_DIR = '/Users/jack/Desktop/lpne/test_data/labels/'
+DEFAULT_LFP_DIR = "/Users/jack/Desktop/lpne/test_data/Data/"
+DEFAULT_LABEL_DIR = "/Users/jack/Desktop/lpne/test_data/labels/"
 DEFAULT_HIPP_NAME = "Hipp_D_L_02"
 DEFAULT_CX_NAME = "Cx_Cg_L_01"
 DEFAULT_EMG_NAME = "EMG_trap"
 DEFAULT_DURATION = 2
-LABELS = ['Wake', 'NREM', 'REM', 'Unlabeled']
-COLORS = ['dodgerblue', 'mediumseagreen', 'darkorchid', 'peru']
+LABELS = ["Wake", "NREM", "REM", "Unlabeled"]
+COLORS = ["dodgerblue", "mediumseagreen", "darkorchid", "peru"]
 COLORS = [to_hex(i) for i in COLORS]
-LFP_TOOLS = 'pan,xwheel_zoom,reset,box_zoom' # wheel_zoom
-LABEL_TOOLS = 'box_select,pan,reset'
+LFP_TOOLS = "pan,xwheel_zoom,reset,box_zoom"  # wheel_zoom
+LABEL_TOOLS = "box_select,pan,reset"
 NULL_SELECTION = "No selection"
 
 
@@ -44,7 +53,6 @@ EMG_HIGHCUT = 250.0
 Q = 1.5
 
 
-
 def label_editing_app(doc):
     """Define the app."""
     ##################
@@ -53,87 +61,87 @@ def label_editing_app(doc):
     hipp_source = ColumnDataSource()
     hipp_plot = figure(tools=LFP_TOOLS, height=LFP_HEIGHT, width=LFP_WIDTH)
     hipp_plot.line(
-            x="lfp_time",
-            y="hipp",
-            source=hipp_source,
-            line_width=LINE_WIDTH,
-            color="slategray",
+        x="lfp_time",
+        y="hipp",
+        source=hipp_source,
+        line_width=LINE_WIDTH,
+        color="slategray",
     )
-    hipp_plot.yaxis[0].axis_label = 'Hipp Channel'
+    hipp_plot.yaxis[0].axis_label = "Hipp Channel"
 
     cortex_plot = figure(
-            tools=LFP_TOOLS,
-            x_range=hipp_plot.x_range,
-            height=LFP_HEIGHT,
-            width=LFP_WIDTH,
+        tools=LFP_TOOLS,
+        x_range=hipp_plot.x_range,
+        height=LFP_HEIGHT,
+        width=LFP_WIDTH,
     )
     cortex_plot.line(
-            x="lfp_time",
-            y="cortex",
-            source=hipp_source,
-            line_width=LINE_WIDTH,
-            color="slategray",
+        x="lfp_time",
+        y="cortex",
+        source=hipp_source,
+        line_width=LINE_WIDTH,
+        color="slategray",
     )
-    cortex_plot.yaxis[0].axis_label = 'Cortical Channel'
+    cortex_plot.yaxis[0].axis_label = "Cortical Channel"
 
     emg_plot = figure(
-            tools=LFP_TOOLS,
-            x_range=hipp_plot.x_range,
-            height=LFP_HEIGHT,
-            width=LFP_WIDTH,
+        tools=LFP_TOOLS,
+        x_range=hipp_plot.x_range,
+        height=LFP_HEIGHT,
+        width=LFP_WIDTH,
     )
     emg_plot.line(
-            x="lfp_time",
-            y="emg",
-            source=hipp_source,
-            line_width=LINE_WIDTH,
-            color="slategray",
+        x="lfp_time",
+        y="emg",
+        source=hipp_source,
+        line_width=LINE_WIDTH,
+        color="slategray",
     )
-    emg_plot.yaxis[0].axis_label = 'EMG'
+    emg_plot.yaxis[0].axis_label = "EMG"
 
     label_source = ColumnDataSource()
     label_plot = figure(
-            tools=LABEL_TOOLS,
-            x_range=hipp_plot.x_range,
-            height=LFP_HEIGHT,
-            width=LFP_WIDTH,
+        tools=LABEL_TOOLS,
+        x_range=hipp_plot.x_range,
+        height=LFP_HEIGHT,
+        width=LFP_WIDTH,
     )
     label_plot.scatter(
-            x="label_time",
-            y="label_y",
-            source=label_source,
-            line_width=LINE_WIDTH,
-            size=SCATTER_SIZE,
-            color="color",
+        x="label_time",
+        y="label_y",
+        source=label_source,
+        line_width=LINE_WIDTH,
+        size=SCATTER_SIZE,
+        color="color",
     )
-    label_plot.xaxis[0].axis_label = 'Time (s)'
-    label_plot.yaxis[0].axis_label = 'Labels'
+    label_plot.xaxis[0].axis_label = "Time (s)"
+    label_plot.yaxis[0].axis_label = "Labels"
 
     def callback_0():
         new_data = {**{}, **label_source.data}
         for idx in label_source.selected.indices:
-            new_data['color'][idx] = COLORS[0]
+            new_data["color"][idx] = COLORS[0]
         label_source.data = new_data
         label_source.selected.indices = []
 
     def callback_1(label_source=label_source):
         new_data = {**{}, **label_source.data}
         for idx in label_source.selected.indices:
-            new_data['color'][idx] = COLORS[1]
+            new_data["color"][idx] = COLORS[1]
         label_source.data = new_data
         label_source.selected.indices = []
 
     def callback_2(label_source=label_source):
         new_data = {**{}, **label_source.data}
         for idx in label_source.selected.indices:
-            new_data['color'][idx] = COLORS[2]
+            new_data["color"][idx] = COLORS[2]
         label_source.data = new_data
         label_source.selected.indices = []
 
     def callback_3(label_source=label_source):
         new_data = {**{}, **label_source.data}
         for idx in label_source.selected.indices:
-            new_data['color'][idx] = COLORS[3]
+            new_data["color"][idx] = COLORS[3]
         label_source.data = new_data
         label_source.selected.indices = []
 
@@ -170,56 +178,56 @@ def label_editing_app(doc):
 
     def save_fn_callback(attr, old, new):
         npy_savefile_input.value = os.path.join(
-                label_dir_input.value,
-                label_select.value,
+            label_dir_input.value,
+            label_select.value,
         )
 
     # LFP stuff.
     lfp_dir_input = TextInput(
-            value=DEFAULT_LFP_DIR,
-            title="Enter LFP directory:",
+        value=DEFAULT_LFP_DIR,
+        title="Enter LFP directory:",
     )
     lfp_dir_input.on_change("value", lfp_dir_input_callback)
     lfp_select = Select(
-            title="Select LFP file:",
-            value=NULL_SELECTION,
-            options=_my_listdir(lfp_dir_input.value),
+        title="Select LFP file:",
+        value=NULL_SELECTION,
+        options=_my_listdir(lfp_dir_input.value),
     )
 
     # Label stuff.
     label_dir_input = TextInput(
-            value=DEFAULT_LABEL_DIR,
-            title="Enter label directory:",
+        value=DEFAULT_LABEL_DIR,
+        title="Enter label directory:",
     )
     label_dir_input.on_change("value", label_dir_input_callback)
     label_select = Select(
-            title="Select label file:",
-            value=NULL_SELECTION,
-            options=_my_listdir(label_dir_input.value),
+        title="Select label file:",
+        value=NULL_SELECTION,
+        options=_my_listdir(label_dir_input.value),
     )
     label_select.on_change("value", save_fn_callback)
 
     # Parameters
     window_slider = Slider(
-            start=1,
-            end=20,
-            value=DEFAULT_DURATION,
-            step=1,
-            title="Window duration (s)",
+        start=1,
+        end=20,
+        value=DEFAULT_DURATION,
+        step=1,
+        title="Window duration (s)",
     )
     fs_input = TextInput(value="1000", title="Enter samplerate (Hz):")
     subsample_input = TextInput(value="10", title="Enter subsample factor:")
     hipp_channel_input = TextInput(
-            value=DEFAULT_HIPP_NAME,
-            title="Enter Hipp channel:",
+        value=DEFAULT_HIPP_NAME,
+        title="Enter Hipp channel:",
     )
     cortical_channel_input = TextInput(
-            value=DEFAULT_CX_NAME,
-            title="Enter cortical channel:",
+        value=DEFAULT_CX_NAME,
+        title="Enter cortical channel:",
     )
     emg_channel_input = TextInput(
-            value=DEFAULT_EMG_NAME,
-            title="Enter EMG channel:",
+        value=DEFAULT_EMG_NAME,
+        title="Enter EMG channel:",
     )
 
     # Other.
@@ -271,18 +279,17 @@ def label_editing_app(doc):
         all_keys = sorted(list(lfps.keys()))
         if emg_channel not in lfps:
             load_button.button_type = "warning"
-            alert_box.text = \
-                    f"Didn't find the channel '{emg_channel}' in: {all_keys}"
+            alert_box.text = f"Didn't find the channel '{emg_channel}' in: {all_keys}"
             return
         if hipp_channel not in lfps:
             load_button.button_type = "warning"
-            alert_box.text = \
-                    f"Didn't find the channel '{hipp_channel}' in: {all_keys}"
+            alert_box.text = f"Didn't find the channel '{hipp_channel}' in: {all_keys}"
             return
         if cortex_channel not in lfps:
             load_button.button_type = "warning"
-            alert_box.text = \
-                    f"Didn't find the channel '{cortex_channel}' in: {all_keys}"
+            alert_box.text = (
+                f"Didn't find the channel '{cortex_channel}' in: {all_keys}"
+            )
             return
 
         # Assign the source data.
@@ -295,7 +302,7 @@ def label_editing_app(doc):
         cortex_trace = lfps[cortex_channel].flatten()
         cortex_trace = lpne.filter_signal(cortex_trace, fs, LFP_LOWCUT, LFP_HIGHCUT)
         cortex_trace = cortex_trace[::subsamp]
-        lfp_times = subsamp/fs * np.arange(len(emg_trace))
+        lfp_times = subsamp / fs * np.arange(len(emg_trace))
         label_fn = label_select.value
         if label_fn == NULL_SELECTION:
             load_button.button_type = "warning"
@@ -309,11 +316,11 @@ def label_editing_app(doc):
         # try:
         labels = lpne.load_labels(label_fn)
         # except ValueError:
-            # load_button.button_type = "warning"
-            # alert_box.text = f"Error loading labels: {label_fn}"
-            # return
+        # load_button.button_type = "warning"
+        # alert_box.text = f"Error loading labels: {label_fn}"
+        # return
         window = window_slider.value
-        label_times = window * np.arange(len(labels)) + window/2
+        label_times = window * np.arange(len(labels)) + window / 2
         color = [COLORS[i] for i in labels]
         new_lfp_data = dict(
             lfp_time=lfp_times,
@@ -328,12 +335,11 @@ def label_editing_app(doc):
         )
         hipp_source.data = new_lfp_data
         label_source.data = new_label_data
-        load_button.button_type="success"
+        load_button.button_type = "success"
         load_button.label = "Loaded"
         alert_box.text = f"Loaded: {lfp_fn}"
 
     load_button.on_click(load_callback)
-
 
     #############
     # Save tab. #
@@ -343,27 +349,27 @@ def label_editing_app(doc):
     npy_text = PreText(text="Save labels in .npy format")
     npy_savefile_input = TextInput(value="", title="Enter filename:", width=400)
     npy_overwrite_checkbox = CheckboxGroup(
-            labels=["Overwrite existing files?"],
-            active=[],
+        labels=["Overwrite existing files?"],
+        active=[],
     )
     npy_save_button = Button(
-            label="Save Labels",
-            default_size=BUTTON_SIZE,
-            width=100,
+        label="Save Labels",
+        default_size=BUTTON_SIZE,
+        width=100,
     )
 
     def npy_save_callback():
         overwrite = 0 in npy_overwrite_checkbox.active
-        labels = [COLORS.index(c) for c in label_source.data['color']]
+        labels = [COLORS.index(c) for c in label_source.data["color"]]
         label_fn = npy_savefile_input.value
         try:
             lpne.save_labels(labels, label_fn, overwrite=overwrite)
         except AssertionError:
-            npy_save_button.button_type="warning"
+            npy_save_button.button_type = "warning"
             alert_box.text = "File already exists!"
             return
         npy_save_button.label = "Saved"
-        npy_save_button.button_type="success"
+        npy_save_button.button_type = "success"
         alert_box.text = ""
 
     npy_save_button.on_click(npy_save_callback)
@@ -372,62 +378,62 @@ def label_editing_app(doc):
     csv_text = PreText(text="Save labels in .csv format")
     csv_savefile_input = TextInput(value="", title="Enter filename:", width=400)
     csv_overwrite_checkbox = CheckboxGroup(
-            labels=["Overwrite existing files?"],
-            active=[],
+        labels=["Overwrite existing files?"],
+        active=[],
     )
     csv_save_button = Button(
-            label="Save Labels",
-            default_size=BUTTON_SIZE,
-            width=100,
+        label="Save Labels",
+        default_size=BUTTON_SIZE,
+        width=100,
     )
 
     def csv_save_callback():
         overwrite = 0 in csv_overwrite_checkbox.active
-        labels = [COLORS.index(c) for c in label_source.data['color']]
+        labels = [COLORS.index(c) for c in label_source.data["color"]]
         label_fn = csv_savefile_input.value
         if not overwrite and os.path.isfile(label_fn):
-            csv_save_button.button_type="warning"
+            csv_save_button.button_type = "warning"
             alert_box.text = "File already exists!"
             return
-        if not label_fn.endswith('.csv') and not label_fn.endswith('.txt'):
-            csv_save_button.button_type="warning"
+        if not label_fn.endswith(".csv") and not label_fn.endswith(".txt"):
+            csv_save_button.button_type = "warning"
             alert_box.text = "CSV file should have a .csv or .txt extension."
             return
         # Format the data.
         window = window_slider.value
-        t1 = window * np.arange(len(labels)) # onsets
-        t2 = t1 + window # offsets
+        t1 = window * np.arange(len(labels))  # onsets
+        t2 = t1 + window  # offsets
         lines = []
         idx = 0
         prev_label, start_t = None, None
         for j in range(len(t1)):
             label = labels[j]
             if label != prev_label:
-                if j > 0 and prev_label != '_':
+                if j > 0 and prev_label != "_":
                     token = LABELS[prev_label]
                     line = f"{start_t:.6f}\t{t1[j]:.6f}\t{token}\n"
                     lines.append(line)
                 start_t = t1[j]
                 prev_label = label
-            if j == len(t1)-1 and prev_label != '_':
+            if j == len(t1) - 1 and prev_label != "_":
                 token = LABELS[prev_label]
                 line = f"{start_t:.1f}, {t1[j]:.1f}, {token}\n"
                 lines.append(line)
             idx += 1
         # Save the data.
-        with open(label_fn, 'w+') as f:
+        with open(label_fn, "w+") as f:
             f.writelines(lines)
         csv_save_button.label = "Saved"
-        csv_save_button.button_type="success"
+        csv_save_button.button_type = "success"
         alert_box.text = ""
 
     csv_save_button.on_click(csv_save_callback)
 
     # Fake data.
-    x = [1,2,3,4,5]
-    y = [5,5,4,6,2]
-    label_y = [0]*len(x)
-    color = [COLORS[-1]]*len(x)
+    x = [1, 2, 3, 4, 5]
+    y = [5, 5, 4, 6, 2]
+    label_y = [0] * len(x)
+    color = [COLORS[-1]] * len(x)
     hipp_source.data = dict(
         lfp_time=x,
         emg=y,
@@ -441,24 +447,24 @@ def label_editing_app(doc):
     )
 
     file_inputs = row(
-            column(lfp_dir_input, lfp_select),
-            column(label_dir_input, label_select),
+        column(lfp_dir_input, lfp_select),
+        column(label_dir_input, label_select),
     )
     file_inputs = column(
-            file_inputs,
-            window_slider,
-            fs_input,
-            subsample_input,
-            hipp_channel_input,
-            cortical_channel_input,
-            emg_channel_input,
-            load_button,
-            alert_box,
+        file_inputs,
+        window_slider,
+        fs_input,
+        subsample_input,
+        hipp_channel_input,
+        cortical_channel_input,
+        emg_channel_input,
+        load_button,
+        alert_box,
     )
 
     tab_1 = Panel(
-            child=file_inputs,
-            title="Select Files",
+        child=file_inputs,
+        title="Select Files",
     )
 
     buttons = row(*label_buttons)
@@ -466,16 +472,16 @@ def label_editing_app(doc):
     tab_2 = Panel(child=column(plots, buttons, alert_box), title="Edit Labels")
 
     npy_save_things = column(
-            npy_text,
-            npy_savefile_input,
-            npy_overwrite_checkbox,
-            npy_save_button,
+        npy_text,
+        npy_savefile_input,
+        npy_overwrite_checkbox,
+        npy_save_button,
     )
     csv_save_things = column(
-            csv_text,
-            csv_savefile_input,
-            csv_overwrite_checkbox,
-            csv_save_button,
+        csv_text,
+        csv_savefile_input,
+        csv_overwrite_checkbox,
+        csv_save_button,
     )
     save_things = column(row(npy_save_things, csv_save_things), alert_box)
 
@@ -485,11 +491,11 @@ def label_editing_app(doc):
     doc.add_root(tabs)
 
 
-
 def _my_listdir(dir):
     try:
-        return [NULL_SELECTION] + \
-                sorted([i for i in os.listdir(dir) if not i.startswith('.')])
+        return [NULL_SELECTION] + sorted(
+            [i for i in os.listdir(dir) if not i.startswith(".")]
+        )
     except:
         return [NULL_SELECTION]
 

--- a/apps/project_app/main.py
+++ b/apps/project_app/main.py
@@ -7,43 +7,50 @@ __date__ = "January - July 2022"
 
 from bokeh.plotting import curdoc
 from bokeh.layouts import column
-from bokeh.models import Button, PreText, TextInput, MultiSelect, \
-        RadioButtonGroup, CheckboxGroup, Tabs, Panel
+from bokeh.models import (
+    Button,
+    PreText,
+    TextInput,
+    MultiSelect,
+    RadioButtonGroup,
+    CheckboxGroup,
+    Tabs,
+    Panel,
+)
 import numpy as np
 import os
 
 import lpne
 
 
-DEFAULT_FEATURE_DIR = '/Users/jack/Desktop/lpne/test_data/features/'
-DEFAULT_LABEL_DIR = '/Users/jack/Desktop/lpne/test_data/labels/'
-DEFAULT_SAVE_DIR = '/Users/jack/Desktop/lpne/test_data/projected_labels/'
-DEFAULT_MODEL_FN = '/Users/jack/Desktop/lpne/test_data/model_state.npy'
-DEFAULT_MAT_FN = '/Users/jack/Desktop/lpne/test_data/transition_mat.npy'
+DEFAULT_FEATURE_DIR = "/Users/jack/Desktop/lpne/test_data/features/"
+DEFAULT_LABEL_DIR = "/Users/jack/Desktop/lpne/test_data/labels/"
+DEFAULT_SAVE_DIR = "/Users/jack/Desktop/lpne/test_data/projected_labels/"
+DEFAULT_MODEL_FN = "/Users/jack/Desktop/lpne/test_data/model_state.npy"
+DEFAULT_MAT_FN = "/Users/jack/Desktop/lpne/test_data/transition_mat.npy"
 
 MULTISELECT_HEIGHT = 350
 MULTISELECT_WIDTH = 400
 MODEL_TYPES = ["CP SAE", "FA SAE"]
-NORM_METHODS = ['Median', 'Std. Dev.', 'Maximum']
+NORM_METHODS = ["Median", "Std. Dev.", "Maximum"]
 
 COUNTS = None
 FNS = None
 PREDICTIONS = None
 
 
-
 def project_app(doc):
 
     rbg_title = PreText(text="Select model type:")
     radio_button_group = RadioButtonGroup(
-            labels=MODEL_TYPES,
-            active=0,
+        labels=MODEL_TYPES,
+        active=0,
     )
 
     rbg2_title = PreText(text="Select normalization method:")
     radio_button_group_2 = RadioButtonGroup(
-            labels=NORM_METHODS,
-            active=0,
+        labels=NORM_METHODS,
+        active=0,
     )
 
     if os.path.exists(DEFAULT_FEATURE_DIR):
@@ -52,16 +59,15 @@ def project_app(doc):
         initial_options = []
 
     multi_select = MultiSelect(
-            value=[],
-            options=initial_options,
-            title="Select feature files:",
-            height=MULTISELECT_HEIGHT,
-            width=MULTISELECT_WIDTH,
+        value=[],
+        options=initial_options,
+        title="Select feature files:",
+        height=MULTISELECT_HEIGHT,
+        width=MULTISELECT_WIDTH,
     )
 
     def update_multi_select(new_options, multi_select=multi_select):
         multi_select.options = new_options
-
 
     def feature_dir_input_callback(attr, old, new):
         """If the directory exists, populate the file selector."""
@@ -71,46 +77,45 @@ def project_app(doc):
                 load_dir = load_dir[:-1]
             update_multi_select(_my_listdir(load_dir))
             # Update the save directory too.
-            temp = load_dir.split(os.path.sep)[:-1] + ['projected_labels']
+            temp = load_dir.split(os.path.sep)[:-1] + ["projected_labels"]
             save_dir_in.value = os.path.sep.join(temp)
         else:
             alert_box.text = f"Not a valid directory: {new}"
 
-
     model_in = TextInput(
-            value=DEFAULT_MODEL_FN,
-            title="Enter a model filename (.npy):",
+        value=DEFAULT_MODEL_FN,
+        title="Enter a model filename (.npy):",
     )
 
     label_checkbox = CheckboxGroup(
-            labels=["Load labels?"],
-            active=[0],
+        labels=["Load labels?"],
+        active=[0],
     )
 
     label_dir_in = TextInput(
-            value=DEFAULT_LABEL_DIR,
-            title="Enter a label directory:",
+        value=DEFAULT_LABEL_DIR,
+        title="Enter a label directory:",
     )
 
     feature_dir_in = TextInput(
-            value=DEFAULT_FEATURE_DIR,
-            title="Enter the feature directory:",
+        value=DEFAULT_FEATURE_DIR,
+        title="Enter the feature directory:",
     )
     feature_dir_in.on_change("value", feature_dir_input_callback)
 
     project_button = Button(label="Project Data", width=150)
 
     transition_mat_in = TextInput(
-            value=DEFAULT_MAT_FN,
-            title="Enter a transition matrix filename (.npy):",
+        value=DEFAULT_MAT_FN,
+        title="Enter a transition matrix filename (.npy):",
     )
     stats_button = Button(label="Get Stats", width=300)
 
     save_button = Button(label="Save Predictions", width=150)
 
     overwrite_checkbox = CheckboxGroup(
-            labels=["Overwrite existing files?"],
-            active=[],
+        labels=["Overwrite existing files?"],
+        active=[],
     )
 
     save_dir_in = TextInput(
@@ -121,18 +126,17 @@ def project_app(doc):
 
     alert_box = PreText(text="")
 
-
     def project_callback():
         global COUNTS, FNS, PREDICTIONS
-        if project_button.button_type=="success":
+        if project_button.button_type == "success":
             # Reset
-            project_button.button_type="default"
-            project_button.label="Project Data"
+            project_button.button_type = "default"
+            project_button.label = "Project Data"
             COUNTS = None
             FNS = None
             PREDICTIONS = None
-            save_button.button_type="default"
-            save_button.label="Save Predictions"
+            save_button.button_type = "default"
+            save_button.label = "Save Predictions"
             alert_box.text = "Reset"
             return
         # Load the features.
@@ -142,7 +146,7 @@ def project_app(doc):
             alert_box.text = "Feature directory doesn't exist!"
             return
         feature_fns = sorted(
-                [os.path.join(feature_dir,i) for i in multi_select.value],
+            [os.path.join(feature_dir, i) for i in multi_select.value],
         )
         if len(feature_fns) == 0:
             project_button.button_type = "warning"
@@ -165,26 +169,26 @@ def project_app(doc):
                 label_fns.append(label_fn)
             # Load the features and labels.
             features, labels, rois, counts = lpne.load_features_and_labels(
-                    feature_fns,
-                    label_fns,
-                    return_counts=True,
+                feature_fns,
+                label_fns,
+                return_counts=True,
             )
         else:
             # Just load the features.
             features, rois, counts = lpne.load_features(
-                    feature_fns,
-                    return_counts=True,
+                feature_fns,
+                return_counts=True,
             )
         # Normalize the power features.
         if radio_button_group_2.active == 0:
-            mode = 'median'
+            mode = "median"
         elif radio_button_group_2.active == 1:
-            mode = 'std'
+            mode = "std"
         elif radio_button_group_2.active == 2:
-            mode = 'max'
+            mode = "max"
         features = lpne.normalize_features(features, mode=mode)
         features = lpne.unsqueeze_triangular_array(features, 1)
-        features = np.transpose(features, [0,3,1,2])
+        features = np.transpose(features, [0, 3, 1, 2])
         # Load the model.
         if not os.path.exists(model_in.value):
             project_button.button_type = "warning"
@@ -215,21 +219,20 @@ def project_app(doc):
             idx = np.array(idx)
             # Calculate a weighted accuracy.
             acc = model.score(features[idx], labels[idx], None)
-            message = f"Confusion matrix (rows are true labels, columns are " \
-                      f"predicted labels):\n{confusion}\n\n" \
-                      f"Weighted accuracy: {acc}"
+            message = (
+                f"Confusion matrix (rows are true labels, columns are "
+                f"predicted labels):\n{confusion}\n\n"
+                f"Weighted accuracy: {acc}"
+            )
         else:
-            pred_vals, pred_counts = \
-                    np.unique(hard_predictions, return_counts=True)
-            message = f"Predictions: {pred_vals}\n" \
-                      f"Counts: {pred_counts}"
+            pred_vals, pred_counts = np.unique(hard_predictions, return_counts=True)
+            message = f"Predictions: {pred_vals}\n" f"Counts: {pred_counts}"
 
         project_button.label = "Projected (click to reset)"
-        project_button.button_type="success"
+        project_button.button_type = "success"
         alert_box.text = message
 
     project_button.on_click(project_callback)
-
 
     def stats_callback():
         global PREDICTIONS
@@ -250,33 +253,36 @@ def project_app(doc):
         map_seqs, map_scores = lpne.top_k_viterbi(PREDICTIONS, trans_mat)
         iid_seq = np.argmax(PREDICTIONS, axis=1)
         # Make stats.
-        map_counts, map_dur, map_transitions = \
-                lpne.get_label_stats(map_seqs, map_scores, n_classes)
-        iid_counts, iid_dur, iid_transitions = \
-                lpne.get_label_stats(iid_seq, None, n_classes)
+        map_counts, map_dur, map_transitions = lpne.get_label_stats(
+            map_seqs, map_scores, n_classes
+        )
+        iid_counts, iid_dur, iid_transitions = lpne.get_label_stats(
+            iid_seq, None, n_classes
+        )
         # Display stats.
-        msg = f"Results with temporal info:\nNumber of bouts: {map_counts}\n" \
-              f"Average bout durations (windows): {map_dur}\n" \
-              f"Number of transistions:\n{map_transitions}\n\n" \
-              f"Results without temporal info:\nNumber of bouts: {iid_counts}\n" \
-              f"Average bout durations (windows): {iid_dur}\n" \
-              f"Number of transistions:\n{iid_transitions}"
+        msg = (
+            f"Results with temporal info:\nNumber of bouts: {map_counts}\n"
+            f"Average bout durations (windows): {map_dur}\n"
+            f"Number of transistions:\n{map_transitions}\n\n"
+            f"Results without temporal info:\nNumber of bouts: {iid_counts}\n"
+            f"Average bout durations (windows): {iid_dur}\n"
+            f"Number of transistions:\n{iid_transitions}"
+        )
         alert_box.text = msg
 
-
     stats_button.on_click(stats_callback)
-
 
     def save_callback():
         global COUNTS, FNS, PREDICTIONS
         if COUNTS is None or FNS is None or PREDICTIONS is None:
-            save_button.button_type="warning"
-            alert_box.text = "Data needs to be projected before " \
-                             "predictions can be saved!"
+            save_button.button_type = "warning"
+            alert_box.text = (
+                "Data needs to be projected before " "predictions can be saved!"
+            )
             return
         save_dir = save_dir_in.value
         if not os.path.exists(save_dir):
-            save_button.button_type="warning"
+            save_button.button_type = "warning"
             alert_box.text = f"Save directory doesn't exist: {save_dir}"
             return
         overwrite = 0 in overwrite_checkbox.active
@@ -288,57 +294,54 @@ def project_app(doc):
         for fn, count in zip(FNS, counts):
             out_fn = os.path.join(save_dir, os.path.split(fn)[-1])
             if not overwrite and os.path.exists(out_fn):
-                save_button.button_type="warning"
+                save_button.button_type = "warning"
                 alert_box.text = f"File already exists: {out_fn}"
                 return
-            lpne.save_labels(PREDICTIONS[i:i+count], out_fn, overwrite=overwrite)
+            lpne.save_labels(PREDICTIONS[i : i + count], out_fn, overwrite=overwrite)
             i += count
-        save_button.button_type="success"
-        save_button.label="Saved Predictions"
+        save_button.button_type = "success"
+        save_button.label = "Saved Predictions"
         alert_box.text = "Saved predictions."
-
 
     save_button.on_click(save_callback)
 
-
     column_1 = column(
-            model_in,
-            rbg_title,
-            radio_button_group,
-            rbg2_title,
-            radio_button_group_2,
-            label_checkbox,
-            label_dir_in,
-            feature_dir_in,
-            multi_select,
-            project_button,
-            alert_box,
+        model_in,
+        rbg_title,
+        radio_button_group,
+        rbg2_title,
+        radio_button_group_2,
+        label_checkbox,
+        label_dir_in,
+        feature_dir_in,
+        multi_select,
+        project_button,
+        alert_box,
     )
     tab_1 = Panel(child=column_1, title="Data Stuff")
 
     column_2 = column(
-            transition_mat_in,
-            stats_button,
-            alert_box,
+        transition_mat_in,
+        stats_button,
+        alert_box,
     )
     tab_2 = Panel(child=column_2, title="Transitions")
 
     column_3 = column(
-            save_dir_in,
-            overwrite_checkbox,
-            save_button,
-            alert_box,
+        save_dir_in,
+        overwrite_checkbox,
+        save_button,
+        alert_box,
     )
-    tab_3= Panel(child=column_3, title="Save Projections")
+    tab_3 = Panel(child=column_3, title="Save Projections")
     tabs = Tabs(tabs=[tab_1, tab_2, tab_3])
     doc.add_root(tabs)
 
 
 def _my_listdir(dir):
-    if dir == '':
+    if dir == "":
         return []
-    return sorted([i for i in os.listdir(dir) if not i.startswith('.')])
-
+    return sorted([i for i in os.listdir(dir) if not i.startswith(".")])
 
 
 # Run the app.

--- a/apps/sleep_app/main.py
+++ b/apps/sleep_app/main.py
@@ -9,8 +9,17 @@ __date__ = "September 2021 - August 2022"
 
 
 from bokeh.layouts import column, row
-from bokeh.models import Button, CheckboxGroup, ColumnDataSource, MultiSelect, \
-        Panel, PreText, Slider, Tabs, TextInput
+from bokeh.models import (
+    Button,
+    CheckboxGroup,
+    ColumnDataSource,
+    MultiSelect,
+    Panel,
+    PreText,
+    Slider,
+    Tabs,
+    TextInput,
+)
 from bokeh.plotting import figure, curdoc
 from matplotlib.colors import to_hex
 import numpy as np
@@ -25,23 +34,23 @@ import lpne
 BUTTON_SIZE = 150
 MULTISELECT_HEIGHT = 500
 MULTISELECT_WIDTH = 350
-DEFAULT_LFP_DIR = '/Users/jack/Desktop/lpne/test_data/Data/'
-DEFAULT_LABEL_DIR = '/Users/jack/Desktop/lpne/test_data/labels/2s/'
+DEFAULT_LFP_DIR = "/Users/jack/Desktop/lpne/test_data/Data/"
+DEFAULT_LABEL_DIR = "/Users/jack/Desktop/lpne/test_data/labels/2s/"
 DEFAULT_EMG_NAME = "EMG_trap"
 DEFAULT_LFP_NAME = "Hipp_D_L_02"
 # DEFAULT_EMG_NAME = "Trapezius_EM"
 # DEFAULT_LFP_NAME = "D_Hipp_02"
 # DEFAULT_LFP_DIR = '/home/jg420/r_drive/Internal/Network/testData/'
 # DEFAULT_LABEL_DIR = '/home/jg420/r_drive/Internal/Network/labels/2s/'
-TOOLS = 'lasso_select,pan,wheel_zoom,reset,box_zoom'
-LABELS = ['Wake', 'NREM', 'REM', 'Unlabeled']
-COLORS = ['tab:blue', 'tab:orange', 'tab:green', 'peru']
+TOOLS = "lasso_select,pan,wheel_zoom,reset,box_zoom"
+LABELS = ["Wake", "NREM", "REM", "Unlabeled"]
+COLORS = ["tab:blue", "tab:orange", "tab:green", "peru"]
 COLORS = [to_hex(i) for i in COLORS]
 MAX_N_POINTS = 5000
 
 # State.
 LFP_INFO = {}
-COORD = None # coordinates
+COORD = None  # coordinates
 PERM = None
 INVALID_FILE = None
 SCATTER_SIZE_1 = 2
@@ -52,21 +61,20 @@ SCATTER_1 = None
 SCATTER_2 = None
 
 # File-related constants.
-LFP_SUFFIX = '_LFP.mat'
-LABEL_SUFFIX = '.npy'
+LFP_SUFFIX = "_LFP.mat"
+LABEL_SUFFIX = ".npy"
 
 # Preprocessing constants
 DEFAULT_DURATION = 2
 RATIO_1 = (2, 20, 55)
 RATIO_2 = (2, 4.5, 9)
-ORDER = 4 # bandpass
+ORDER = 4  # bandpass
 EMG_LOWCUT = 30.0
 EMG_MIDDLECUT = 60.0
 EMG_HIGHCUT = 249.0
 LFP_LOWCUT = 0.5
 LFP_HIGHCUT = 55.0
 Q = 1.5
-
 
 
 def sleep_app(doc):
@@ -77,61 +85,60 @@ def sleep_app(doc):
     ################
     source = ColumnDataSource()
     plot_1 = figure(
-            tools=TOOLS,
-            sizing_mode='stretch_width',
-            x_axis_label='Dhipp RMS Amplitude',
-            y_axis_label='EMG Power',
+        tools=TOOLS,
+        sizing_mode="stretch_width",
+        x_axis_label="Dhipp RMS Amplitude",
+        y_axis_label="EMG Power",
     )
     SCATTER_1 = plot_1.scatter(
-            x="hipp_rms",
-            y="emg_power",
-            source=source,
-            size=SCATTER_SIZE_1,
-            color="color",
-            fill_alpha=ALPHA_1,
+        x="hipp_rms",
+        y="emg_power",
+        source=source,
+        size=SCATTER_SIZE_1,
+        color="color",
+        fill_alpha=ALPHA_1,
     )
 
     plot_2 = figure(
-            tools=TOOLS,
-            sizing_mode='stretch_width',
-            x_axis_label='Frequency Ratio 2',
-            y_axis_label='Frequency Ratio 1',
+        tools=TOOLS,
+        sizing_mode="stretch_width",
+        x_axis_label="Frequency Ratio 2",
+        y_axis_label="Frequency Ratio 1",
     )
     SCATTER_2 = plot_2.scatter(
-            x="ratio_2",
-            y="ratio_1",
-            source=source,
-            size=SCATTER_SIZE_2,
-            color="color",
-            fill_alpha=ALPHA_2,
+        x="ratio_2",
+        y="ratio_1",
+        source=source,
+        size=SCATTER_SIZE_2,
+        color="color",
+        fill_alpha=ALPHA_2,
     )
-
 
     def callback_0():
         new_data = {**{}, **source.data}
         for idx in source.selected.indices:
-            new_data['color'][idx] = COLORS[0]
+            new_data["color"][idx] = COLORS[0]
         source.data = new_data
         source.selected.indices = []
 
     def callback_1():
         new_data = {**{}, **source.data}
         for idx in source.selected.indices:
-            new_data['color'][idx] = COLORS[1]
+            new_data["color"][idx] = COLORS[1]
         source.data = new_data
         source.selected.indices = []
 
     def callback_2():
         new_data = {**{}, **source.data}
         for idx in source.selected.indices:
-            new_data['color'][idx] = COLORS[2]
+            new_data["color"][idx] = COLORS[2]
         source.data = new_data
         source.selected.indices = []
 
     def callback_3():
         new_data = {**{}, **source.data}
         for idx in source.selected.indices:
-            new_data['color'][idx] = COLORS[3]
+            new_data["color"][idx] = COLORS[3]
         source.data = new_data
         source.selected.indices = []
 
@@ -144,100 +151,98 @@ def sleep_app(doc):
         label_buttons.append(button)
 
     alpha_input_1 = TextInput(
-            value=str(ALPHA_1),
-            title="Plot 1 transparency:",
+        value=str(ALPHA_1),
+        title="Plot 1 transparency:",
     )
 
     alpha_input_2 = TextInput(
-            value=str(ALPHA_2),
-            title="Plot 2 transparency:",
+        value=str(ALPHA_2),
+        title="Plot 2 transparency:",
     )
 
     def alpha_callback_1(attr, old, new):
         global ALPHA_1, SCATTER_1
         try:
-            ALPHA_1 = max(min(1,float(new)),0)
+            ALPHA_1 = max(min(1, float(new)), 0)
         except ValueError:
             pass
         alpha_input_1.value = str(ALPHA_1)
         plot_1.renderers = []
         SCATTER_1 = plot_1.scatter(
-                x="hipp_rms",
-                y="emg_power",
-                source=source,
-                size=SCATTER_SIZE_1,
-                color="color",
-                fill_alpha=ALPHA_1,
+            x="hipp_rms",
+            y="emg_power",
+            source=source,
+            size=SCATTER_SIZE_1,
+            color="color",
+            fill_alpha=ALPHA_1,
         )
         plot_1.renderers.append(SCATTER_1)
 
     def alpha_callback_2(attr, old, new):
         global ALPHA_2, SCATTER_2
         try:
-            ALPHA_2 = max(min(1,float(new)),0)
+            ALPHA_2 = max(min(1, float(new)), 0)
         except ValueError:
             pass
         alpha_input_2.value = str(ALPHA_2)
         plot_2.renderers = []
         SCATTER_2 = plot_2.scatter(
-                x="ratio_2",
-                y="ratio_1",
-                source=source,
-                size=SCATTER_SIZE_2,
-                color="color",
-                fill_alpha=ALPHA_2,
+            x="ratio_2",
+            y="ratio_1",
+            source=source,
+            size=SCATTER_SIZE_2,
+            color="color",
+            fill_alpha=ALPHA_2,
         )
         plot_2.renderers.append(SCATTER_2)
-
 
     alpha_input_1.on_change("value", alpha_callback_1)
     alpha_input_2.on_change("value", alpha_callback_2)
 
     size_input_1 = TextInput(
-            value=str(SCATTER_SIZE_1),
-            title="Plot 1 scatter size:",
+        value=str(SCATTER_SIZE_1),
+        title="Plot 1 scatter size:",
     )
     size_input_2 = TextInput(
-            value=str(SCATTER_SIZE_2),
-            title="Plot 2 scatter size:",
+        value=str(SCATTER_SIZE_2),
+        title="Plot 2 scatter size:",
     )
 
     def scatter_size_callback_1(attr, old, new):
         global SCATTER_SIZE_1, SCATTER_1
         try:
-            SCATTER_SIZE_1 = max(float(new),0)
+            SCATTER_SIZE_1 = max(float(new), 0)
         except ValueError:
             pass
         size_input_1.value = str(SCATTER_SIZE_1)
         plot_1.renderers = []
         SCATTER_1 = plot_1.scatter(
-                x="hipp_rms",
-                y="emg_trace",
-                source=source,
-                size=SCATTER_SIZE_1,
-                color="color",
-                fill_alpha=ALPHA_1,
+            x="hipp_rms",
+            y="emg_trace",
+            source=source,
+            size=SCATTER_SIZE_1,
+            color="color",
+            fill_alpha=ALPHA_1,
         )
         plot_1.renderers.append(SCATTER_1)
 
     def scatter_size_callback_2(attr, old, new):
         global SCATTER_SIZE_2, SCATTER_2
         try:
-            SCATTER_SIZE_2 = max(float(new),0)
+            SCATTER_SIZE_2 = max(float(new), 0)
         except ValueError:
             pass
         size_input_2.value = str(SCATTER_SIZE_2)
         plot_2.renderers = []
         SCATTER_2 = plot_2.scatter(
-                x="ratio_2",
-                y="ratio_1",
-                source=source,
-                size=SCATTER_SIZE_2,
-                color="color",
-                fill_alpha=ALPHA_2,
+            x="ratio_2",
+            y="ratio_1",
+            source=source,
+            size=SCATTER_SIZE_2,
+            color="color",
+            fill_alpha=ALPHA_2,
         )
         plot_2.renderers.append(SCATTER_2)
-
 
     size_input_1.on_change("value", scatter_size_callback_1)
     size_input_2.on_change("value", scatter_size_callback_2)
@@ -255,8 +260,8 @@ def sleep_app(doc):
             update_multi_select(_my_listdir(load_dir))
             if len(load_dir.split(os.path.sep)) > 1:
                 save_dir = load_dir.split(os.path.sep)[:-1]
-                save_dir.append('labels')
-                save_dir.append(str(window_slider.value)+'s')
+                save_dir.append("labels")
+                save_dir.append(str(window_slider.value) + "s")
                 save_dir_input.value = os.path.sep + os.path.join(*save_dir)
         else:
             alert_box.text = f"Not a valid directory: {new}"
@@ -267,36 +272,36 @@ def sleep_app(doc):
         initial_options = []
 
     multi_select = MultiSelect(
-            value=[],
-            options=initial_options,
-            title="Select LFP files:",
-            height=MULTISELECT_HEIGHT,
-            width=MULTISELECT_WIDTH,
+        value=[],
+        options=initial_options,
+        title="Select LFP files:",
+        height=MULTISELECT_HEIGHT,
+        width=MULTISELECT_WIDTH,
     )
 
     def update_multi_select(new_options, multi_select=multi_select):
         multi_select.options = new_options
 
     load_dir_input = TextInput(
-            value=DEFAULT_LFP_DIR,
-            title="Enter LFP directory:",
+        value=DEFAULT_LFP_DIR,
+        title="Enter LFP directory:",
     )
     load_dir_input.on_change("value", load_dir_input_callback)
 
     emg_channel_input = TextInput(
-            value=DEFAULT_EMG_NAME,
-            title="Enter EMG channel name:",
+        value=DEFAULT_EMG_NAME,
+        title="Enter EMG channel name:",
     )
     hipp_channel_input = TextInput(
-            value=DEFAULT_LFP_NAME,
-            title="Enter Hipp channel name:",
+        value=DEFAULT_LFP_NAME,
+        title="Enter Hipp channel name:",
     )
     window_slider = Slider(
-            start=1,
-            end=20,
-            value=DEFAULT_DURATION,
-            step=1,
-            title="Window duration (s)",
+        start=1,
+        end=20,
+        value=DEFAULT_DURATION,
+        step=1,
+        title="Window duration (s)",
     )
 
     def window_slider_callback(attr, old, new):
@@ -305,8 +310,8 @@ def sleep_app(doc):
             load_dir = load_dir[:-1]
         if os.path.exists(load_dir) and len(load_dir.split(os.path.sep)) > 1:
             save_dir = load_dir.split(os.path.sep)[:-1]
-            save_dir.append('labels')
-            save_dir.append(str(window_slider.value)+'s')
+            save_dir.append("labels")
+            save_dir.append(str(window_slider.value) + "s")
             save_dir_input.value = os.path.sep + os.path.join(*save_dir)
 
     window_slider.on_change("value", window_slider_callback)
@@ -317,20 +322,25 @@ def sleep_app(doc):
 
     load_button = Button(label="Load LFPs", default_size=BUTTON_SIZE, width=100)
 
-
-    def load_callback(load_dir_input=load_dir_input, \
-        multi_select=multi_select, emg_channel_input=emg_channel_input, \
-        hipp_channel_input=hipp_channel_input, window_slider=window_slider, \
-        fs_input=fs_input, load_button=load_button, alert_box=alert_box, \
-        source=source):
+    def load_callback(
+        load_dir_input=load_dir_input,
+        multi_select=multi_select,
+        emg_channel_input=emg_channel_input,
+        hipp_channel_input=hipp_channel_input,
+        window_slider=window_slider,
+        fs_input=fs_input,
+        load_button=load_button,
+        alert_box=alert_box,
+        source=source,
+    ):
         """Load the LFPs."""
         global INVALID_FILE, COORD, PERM
         alert_box.text = "Loading LFPs..."
         load_button.button_type = "warning"
-        load_button.label = 'Loading...'
+        load_button.label = "Loading..."
         # Make sure the LFP files are selected.
         lfp_dir = load_dir_input.value
-        lfp_fns = sorted([os.path.join(lfp_dir,i) for i in multi_select.value])
+        lfp_fns = sorted([os.path.join(lfp_dir, i) for i in multi_select.value])
         if len(lfp_fns) == 0:
             load_button.button_type = "warning"
             alert_box.text = "No LFP files selected!"
@@ -353,13 +363,11 @@ def sleep_app(doc):
         all_keys = list(lfps.keys())
         if emg_channel not in lfps:
             load_button.button_type = "warning"
-            alert_box.text = \
-                    f"Didn't find the channel '{emg_channel}' in: {all_keys}"
+            alert_box.text = f"Didn't find the channel '{emg_channel}' in: {all_keys}"
             return
         if hipp_channel not in lfps:
             load_button.button_type = "warning"
-            alert_box.text = \
-                    f"Didn't find the channel '{hipp_channel}' in: {all_keys}"
+            alert_box.text = f"Didn't find the channel '{hipp_channel}' in: {all_keys}"
             return
 
         # Make sure the samplerate is valid.
@@ -392,16 +400,16 @@ def sleep_app(doc):
         # Update source.
         PERM = np.random.permutation(len(COORD))[:MAX_N_POINTS]
         new_data = dict(
-            hipp_rms=COORD[PERM,0],
-            emg_power=COORD[PERM,1],
-            ratio_2 = COORD[PERM,2],
-            ratio_1 = COORD[PERM,3],
-            color=[COLORS[-1]]*len(PERM),
+            hipp_rms=COORD[PERM, 0],
+            emg_power=COORD[PERM, 1],
+            ratio_2=COORD[PERM, 2],
+            ratio_1=COORD[PERM, 3],
+            color=[COLORS[-1]] * len(PERM),
         )
         source.data = new_data
 
         load_button.label = "Loaded"
-        load_button.button_type="success"
+        load_button.button_type = "success"
         msg = f"Successfully loaded LFPs.\n\nFound {len(COORD)} windows."
         alert_box.text = msg
 
@@ -411,29 +419,32 @@ def sleep_app(doc):
     # Save tab. #
     #############
     overwrite_checkbox = CheckboxGroup(
-            labels=["Overwrite existing files?"],
-            active=[],
+        labels=["Overwrite existing files?"],
+        active=[],
     )
     save_dir_input = TextInput(
-            value=DEFAULT_LABEL_DIR,
-            title="Enter label directory:",
+        value=DEFAULT_LABEL_DIR,
+        title="Enter label directory:",
     )
     save_button = Button(label="Save", default_size=200)
 
-    def save_callback(save_button=save_button, save_dir_input=save_dir_input,
-        overwrite_checkbox=overwrite_checkbox):
+    def save_callback(
+        save_button=save_button,
+        save_dir_input=save_dir_input,
+        overwrite_checkbox=overwrite_checkbox,
+    ):
         """Save the sleep labels."""
         global COORD, PERM
         save_dir = save_dir_input.value
         overwrite = 0 in overwrite_checkbox.active
         if not os.path.exists(save_dir):
             alert_box.text = f"Directory does not exist: {save_dir}"
-            save_button.button_type="warning"
+            save_button.button_type = "warning"
             return
         # Standardize for better nearest neighbors.
         scaled_coord = np.zeros_like(COORD)
         for i in range(COORD.shape[1]):
-            scaled_coord[:,i] = COORD[:,i] / np.std(COORD[:,i])
+            scaled_coord[:, i] = COORD[:, i] / np.std(COORD[:, i])
         # Fit the nearest neighbors.
         neigh = NearestNeighbors(n_neighbors=1)
         neigh.fit(scaled_coord[PERM])
@@ -442,30 +453,30 @@ def sleep_app(doc):
         i = 0
         res_text = f"Counts: {LABELS}\n"
         for lfp_fn in sorted(list(LFP_INFO.keys())):
-            label_fn = os.path.split(lfp_fn)[-1][:-len(LFP_SUFFIX)]
+            label_fn = os.path.split(lfp_fn)[-1][: -len(LFP_SUFFIX)]
             label_fn = os.path.join(save_dir, label_fn + LABEL_SUFFIX)
             j = i + LFP_INFO[lfp_fn]
             idx = all_neighbors[i:j]
-            labels = [COLORS.index(source.data['color'][k]) for k in idx]
+            labels = [COLORS.index(source.data["color"][k]) for k in idx]
             res_text += f"{os.path.split(lfp_fn)[-1]}: "
             res_text += f"{np.bincount(labels,minlength=4)}\n"
             try:
                 lpne.save_labels(labels, label_fn, overwrite=overwrite)
             except AssertionError:
-                save_button.button_type="warning"
+                save_button.button_type = "warning"
                 alert_box.text = "File already exists!"
                 return
             i += LFP_INFO[lfp_fn]
         save_button.label = "Saved"
-        save_button.button_type="success"
+        save_button.button_type = "success"
         alert_box.text = res_text
 
     save_button.on_click(save_callback)
 
     # Fake data.
-    x = [1,2,3,4,5]
-    y = [5,5,4,6,2]
-    color = [COLORS[-1]]*len(x)
+    x = [1, 2, 3, 4, 5]
+    y = [5, 5, 4, 6, 2]
+    color = [COLORS[-1]] * len(x)
     source.data = dict(
         hipp_rms=x,
         emg_power=y,
@@ -479,22 +490,27 @@ def sleep_app(doc):
     ###########
     column_1 = column(load_button, load_dir_input, multi_select)
     column_2 = column(
-            emg_channel_input,
-            hipp_channel_input,
-            window_slider,
-            fs_input,
-            alert_box,
+        emg_channel_input,
+        hipp_channel_input,
+        window_slider,
+        fs_input,
+        alert_box,
     )
     tab_1 = Panel(
         child=row(column_1, column_2),
         title="Data Stuff",
     )
-    buttons = column(*(label_buttons+[alpha_input_1, size_input_1, alpha_input_2, size_input_2, alert_box]))
+    buttons = column(
+        *(
+            label_buttons
+            + [alpha_input_1, size_input_1, alpha_input_2, size_input_2, alert_box]
+        )
+    )
     tab_2 = Panel(
         child=row(buttons, plot_1, plot_2),
         title="Sleep Selection",
     )
-    save_column = column(save_dir_input,overwrite_checkbox,save_button)
+    save_column = column(save_dir_input, overwrite_checkbox, save_button)
     tab_3 = Panel(
         child=row(save_column, alert_box),
         title="Save Labels",
@@ -503,9 +519,9 @@ def sleep_app(doc):
     doc.add_root(tabs)
 
 
-
-def get_emg_lfp_features(lfp_fns, hipp_channel, emg_channel, window_duration,
-    window_step, fs):
+def get_emg_lfp_features(
+    lfp_fns, hipp_channel, emg_channel, window_duration, window_step, fs
+):
     """ """
     global LFP_INFO, INVALID_FILE
     LFP_INFO = {}
@@ -523,32 +539,34 @@ def get_emg_lfp_features(lfp_fns, hipp_channel, emg_channel, window_duration,
         except (NotImplementedError, FileNotFoundError):
             INVALID_FILE = lfp_fn
             raise NotImplementedError
-        assert emg_channel in lfps, f"{emg_channel} not in " \
-                f"{list(lfps.keys())} in file {lfp_fn}"
-        assert hipp_channel in lfps, f"{hipp_channel} not in " \
-                f"{list(lfps.keys())} in file {lfp_fn}"
+        assert emg_channel in lfps, (
+            f"{emg_channel} not in " f"{list(lfps.keys())} in file {lfp_fn}"
+        )
+        assert hipp_channel in lfps, (
+            f"{hipp_channel} not in " f"{list(lfps.keys())} in file {lfp_fn}"
+        )
         emg_tr = lfps[emg_channel].flatten()
         dhipp_tr = lfps[hipp_channel].flatten()
         # Calculate features of the LFP and EMG.
         emg_power = _process_emg_trace(
-                emg_tr,
-                fs,
-                window_samples,
-                step_samples,
+            emg_tr,
+            fs,
+            window_samples,
+            step_samples,
         )
         dhipp_ratio_1 = _process_lfp_trace(
-                dhipp_tr[:],
-                fs,
-                window_samples,
-                step_samples,
-                r=RATIO_1,
+            dhipp_tr[:],
+            fs,
+            window_samples,
+            step_samples,
+            r=RATIO_1,
         )
         dhipp_ratio_2 = _process_lfp_trace(
-                dhipp_tr[:],
-                fs,
-                window_samples,
-                step_samples,
-                r=RATIO_2,
+            dhipp_tr[:],
+            fs,
+            window_samples,
+            step_samples,
+            r=RATIO_2,
         )
         dhipp_rms = _rms_lfp_trace(dhipp_tr, fs, window_samples, step_samples)
         assert len(emg_power) == len(dhipp_rms)
@@ -561,83 +579,82 @@ def get_emg_lfp_features(lfp_fns, hipp_channel, emg_channel, window_duration,
     rmss = np.concatenate(all_dhipp_rms, axis=0)
     ratio_1s = np.concatenate(all_dhipp_ratio_1, axis=0)
     ratio_2s = np.concatenate(all_dhipp_ratio_2, axis=0)
-    X1 = np.stack([rmss, emgs, ratio_2s, ratio_1s],axis=1)
+    X1 = np.stack([rmss, emgs, ratio_2s, ratio_1s], axis=1)
     return X1
 
 
 def _process_emg_trace(trace, fs, window_samples, step_samples):
-	"""Calculate the RMS power over two fixed frequency bins."""
-	# Bandpass.
-	trace = _butter_bandpass_filter(
-            trace,
-            EMG_LOWCUT,
-            EMG_HIGHCUT,
-            fs,
-            order=ORDER,
+    """Calculate the RMS power over two fixed frequency bins."""
+    # Bandpass.
+    trace = _butter_bandpass_filter(
+        trace,
+        EMG_LOWCUT,
+        EMG_HIGHCUT,
+        fs,
+        order=ORDER,
     )
-	# Remove electrical noise.
-	for freq in range(60,int(EMG_HIGHCUT),60):
-		b, a = iirnotch(freq, Q, fs)
-		trace = lfilter(b, a, trace)
-	b, a = iirnotch(200.0, Q, fs)
-	trace = lfilter(b, a, trace)
-	# Walk through the trace, collecting powers in different frequency ranges.
-	data = []
-	for i in range(0, len(trace)-window_samples, step_samples):
-		chunk = trace[i:i+window_samples]
-		f, t, spec = stft(chunk, fs=fs, nperseg=window_samples)
-		spec = np.abs(spec)
-		spec = np.mean(spec, axis=1) # average over the three time bins
-		i1, i2, i3 = np.searchsorted(f, (EMG_LOWCUT,EMG_MIDDLECUT,EMG_HIGHCUT))
-		temp = np.sqrt(np.mean(spec[i1:i2]) + np.mean(spec[i2:i3]))
-		data.append(temp)
-	return np.array(data)
+    # Remove electrical noise.
+    for freq in range(60, int(EMG_HIGHCUT), 60):
+        b, a = iirnotch(freq, Q, fs)
+        trace = lfilter(b, a, trace)
+    b, a = iirnotch(200.0, Q, fs)
+    trace = lfilter(b, a, trace)
+    # Walk through the trace, collecting powers in different frequency ranges.
+    data = []
+    for i in range(0, len(trace) - window_samples, step_samples):
+        chunk = trace[i : i + window_samples]
+        f, t, spec = stft(chunk, fs=fs, nperseg=window_samples)
+        spec = np.abs(spec)
+        spec = np.mean(spec, axis=1)  # average over the three time bins
+        i1, i2, i3 = np.searchsorted(f, (EMG_LOWCUT, EMG_MIDDLECUT, EMG_HIGHCUT))
+        temp = np.sqrt(np.mean(spec[i1:i2]) + np.mean(spec[i2:i3]))
+        data.append(temp)
+    return np.array(data)
 
 
-def _process_lfp_trace(trace, fs, window_samples, step_samples, r=(2.0,4.5,9.0)):
-	# Walk through the trace, collecting powers in different frequency ranges.
-	data = []
-	for i in range(0, len(trace)-window_samples, step_samples):
-		chunk = trace[i:i+window_samples]
-		f, t, spec = stft(chunk, fs=fs, nperseg=window_samples)
-		spec = np.abs(spec)
-		spec = np.mean(spec, axis=1) # average over the three time bins
-		i1 = np.argmin(np.abs(f - r[0]))
-		i2 = np.argmin(np.abs(f - r[1]))
-		i3 = np.argmin(np.abs(f - r[2]))
-		data.append(np.sum(spec[i1:i2+1]) / np.sum(spec[i1:i3+1]))
-	return np.array(data)
+def _process_lfp_trace(trace, fs, window_samples, step_samples, r=(2.0, 4.5, 9.0)):
+    # Walk through the trace, collecting powers in different frequency ranges.
+    data = []
+    for i in range(0, len(trace) - window_samples, step_samples):
+        chunk = trace[i : i + window_samples]
+        f, t, spec = stft(chunk, fs=fs, nperseg=window_samples)
+        spec = np.abs(spec)
+        spec = np.mean(spec, axis=1)  # average over the three time bins
+        i1 = np.argmin(np.abs(f - r[0]))
+        i2 = np.argmin(np.abs(f - r[1]))
+        i3 = np.argmin(np.abs(f - r[2]))
+        data.append(np.sum(spec[i1 : i2 + 1]) / np.sum(spec[i1 : i3 + 1]))
+    return np.array(data)
 
 
 def _rms_lfp_trace(trace, fs, window_samples, step_samples):
-	# Bandpass.
-	trace = _butter_bandpass_filter(trace, LFP_LOWCUT, LFP_HIGHCUT, fs)
-	# Walk through the trace, collecting powers in different frequency ranges.
-	data = []
-	for i in range(0, len(trace)-window_samples, step_samples):
-		chunk = trace[i:i+window_samples]
-		chunk -= np.mean(chunk)
-		data.append(np.sqrt(np.mean(chunk**2)))
-	return np.array(data)
+    # Bandpass.
+    trace = _butter_bandpass_filter(trace, LFP_LOWCUT, LFP_HIGHCUT, fs)
+    # Walk through the trace, collecting powers in different frequency ranges.
+    data = []
+    for i in range(0, len(trace) - window_samples, step_samples):
+        chunk = trace[i : i + window_samples]
+        chunk -= np.mean(chunk)
+        data.append(np.sqrt(np.mean(chunk**2)))
+    return np.array(data)
 
 
 def _butter_bandpass(lowcut, highcut, fs, order=ORDER):
-	nyq = 0.5 * fs
-	low = lowcut / nyq
-	high = highcut / nyq
-	b, a = butter(order, [low, high], btype='band')
-	return b, a
+    nyq = 0.5 * fs
+    low = lowcut / nyq
+    high = highcut / nyq
+    b, a = butter(order, [low, high], btype="band")
+    return b, a
 
 
 def _butter_bandpass_filter(data, lowcut, highcut, fs, order=ORDER):
-	b, a = _butter_bandpass(lowcut, highcut, fs, order=order)
-	y = lfilter(b, a, data)
-	return y
+    b, a = _butter_bandpass(lowcut, highcut, fs, order=order)
+    y = lfilter(b, a, data)
+    return y
 
 
 def _my_listdir(dir):
-    return sorted([i for i in os.listdir(dir) if not i.startswith('.')])
-
+    return sorted([i for i in os.listdir(dir) if not i.startswith(".")])
 
 
 # Run the app.

--- a/apps/wave_app/main.py
+++ b/apps/wave_app/main.py
@@ -13,34 +13,32 @@ from scipy.io import wavfile
 import lpne
 
 
-DEFAULT_LFP_DIR = '/Users/jack/Desktop/lpne/test_data/Data/'
+DEFAULT_LFP_DIR = "/Users/jack/Desktop/lpne/test_data/Data/"
 DEFAULT_CHANNEL = "Hipp_D_L_02"
 DEFAULT_FS = 1000
 
 
-
 def wave_app(doc):
     file_in = TextInput(
-            value=DEFAULT_LFP_DIR,
-            title="Enter input LFP file (.mat):",
+        value=DEFAULT_LFP_DIR,
+        title="Enter input LFP file (.mat):",
     )
     file_out = TextInput(
-            value=DEFAULT_LFP_DIR,
-            title="Enter output file (.wav):",
+        value=DEFAULT_LFP_DIR,
+        title="Enter output file (.wav):",
     )
     fs_input = TextInput(
-            value=str(DEFAULT_FS),
-            title="Enter samplerate (Hz):",
+        value=str(DEFAULT_FS),
+        title="Enter samplerate (Hz):",
     )
     channel_input = TextInput(
-            value=DEFAULT_CHANNEL,
-            title="Channel name:",
+        value=DEFAULT_CHANNEL,
+        title="Channel name:",
     )
 
     alert_box = PreText(text="")
 
     save_button = Button(label="Save LFP as WAV", width=150)
-
 
     def save_callback():
         # Make sure the samplerate is valid.
@@ -64,36 +62,36 @@ def wave_app(doc):
         # Make sure the channel is there.
         if channel_input.value not in lfps:
             save_button.button_type = "warning"
-            alert_box.text = f"Channel {channel_input.value} is not in: {list(lfps.keys())}"
+            alert_box.text = (
+                f"Channel {channel_input.value} is not in: {list(lfps.keys())}"
+            )
             return
-        if not file_out.value.endswith('.wav'):
+        if not file_out.value.endswith(".wav"):
             save_button.button_type = "warning"
             alert_box.text = "Output file doesn't end in '.wav'!"
             return
         out_dir = os.path.split(file_out.value)[0]
-        if out_dir != '' and not os.path.exists(out_dir):
+        if out_dir != "" and not os.path.exists(out_dir):
             save_button.button_type = "warning"
             alert_box.text = f"Save path {out_dir} doesn't exist!"
             return
         lfp = lfps[channel_input.value]
         wavfile.write(file_out.value, fs, lfp)
         save_button.label = "Saved"
-        save_button.button_type="success"
+        save_button.button_type = "success"
         alert_box.text = ""
-
 
     save_button.on_click(save_callback)
 
     column_1 = column(
-            file_in,
-            file_out,
-            fs_input,
-            channel_input,
-            save_button,
-            alert_box,
+        file_in,
+        file_out,
+        fs_input,
+        channel_input,
+        save_button,
+        alert_box,
     )
     doc.add_root(column_1)
-
 
 
 # Run the app.

--- a/docs/source/lpne.models.rst
+++ b/docs/source/lpne.models.rst
@@ -9,14 +9,6 @@ lpne.models package
 Submodules
 ----------
 
-lpne.models.factor_analysis_sae module
---------------------------------------
-
-.. automodule:: lpne.models.factor_analysis_sae
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 
 lpne.models.cp_sae module
 -------------------------
@@ -27,10 +19,37 @@ lpne.models.cp_sae module
     :show-inheritance:
 
 
+lpne.models.dcsfa_nmf module
+----------------------------
+
+.. automodule:: lpne.models.dcsfa_nmf
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+lpne.models.factor_analysis_sae module
+--------------------------------------
+
+.. automodule:: lpne.models.factor_analysis_sae
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 lpne.models.grid_search_cv module
 ---------------------------------
 
 .. automodule:: lpne.models.grid_search_cv
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+lpne.models.nmf_base module
+---------------------------
+
+.. automodule:: lpne.models.nmf_base
     :members:
     :undoc-members:
     :show-inheritance:

--- a/lpne/__init__.py
+++ b/lpne/__init__.py
@@ -15,7 +15,7 @@ except:
 INVALID_LABEL = -1
 INVALID_GROUP = -1
 
-from .models import FaSae, CpSae, GridSearchCV
+from .models import FaSae, CpSae, GridSearchCV, dcsfa_nmf
 
 from .plotting import \
         plot_db, \

--- a/lpne/__init__.py
+++ b/lpne/__init__.py
@@ -64,6 +64,7 @@ from .utils.utils import \
         unsqueeze_triangular_array, \
         squeeze_triangular_array, \
         get_outlier_summary, \
+        flatten_dir_spec_features, \
         confusion_matrix
 
 from .utils.viterbi import top_k_viterbi, get_label_stats

--- a/lpne/__init__.py
+++ b/lpne/__init__.py
@@ -4,36 +4,38 @@ LPNE feature pipeline
 Code for preprocessing and building factor models with local field potentials.
 
 """
-__date__ = "July 2021 - August 2022"
-__version__ = "0.1.6"
+__date__ = "July 2021 - October 2022"
+__version__ = "0.1.7"
 try:
     with open(".git/logs/HEAD", "r") as fh:
-        __commit__ = fh.read().split('\n')[-2]
+        __commit__ = fh.read().split("\n")[-2]
 except:
-	__commit__ = "unknown commit"
+    __commit__ = "unknown commit"
 
 INVALID_LABEL = -1
 INVALID_GROUP = -1
 
 from .models import FaSae, CpSae, GridSearchCV, dcsfa_nmf
 
-from .plotting import \
-        plot_db, \
-        plot_lfps, \
-        plot_factor, \
-        plot_factors, \
-        plot_power, \
-        plot_spec, \
-        make_power_movie
+from .plotting import (
+    plot_db,
+    plot_lfps,
+    plot_factor,
+    plot_factors,
+    plot_power,
+    plot_spec,
+    make_power_movie,
+)
 
-from .preprocess.channel_maps import \
-        IGNORED_KEYS, \
-        average_channels, \
-        get_excel_channel_map, \
-        get_default_channel_map, \
-        remove_channels, \
-        remove_channels_from_lfps, \
-        get_removed_channels_from_file
+from .preprocess.channel_maps import (
+    IGNORED_KEYS,
+    average_channels,
+    get_excel_channel_map,
+    get_default_channel_map,
+    remove_channels,
+    remove_channels_from_lfps,
+    get_removed_channels_from_file,
+)
 
 from .preprocess.directed_spectrum import get_directed_spectrum
 
@@ -45,35 +47,35 @@ from .preprocess.normalize import normalize_features, normalize_lfps
 
 from .preprocess.outlier_detection import mark_outliers
 
-from .utils.data import \
-        load_lfps, \
-        save_features, \
-        load_features, \
-        save_labels, \
-        load_labels, \
-        load_features_and_labels
+from .utils.data import (
+    load_lfps,
+    save_features,
+    load_features,
+    save_labels,
+    load_labels,
+    load_features_and_labels,
+)
 
-from .utils.utils import \
-        write_fake_labels, \
-        get_lfp_filenames, \
-        get_feature_filenames, \
-        get_label_filenames_from_feature_filenames, \
-        get_lfp_chans_filenames, \
-        get_feature_label_filenames, \
-        get_weights, \
-        unsqueeze_triangular_array, \
-        squeeze_triangular_array, \
-        get_outlier_summary, \
-        flatten_dir_spec_features, \
-        confusion_matrix
+from .utils.utils import (
+    write_fake_labels,
+    get_lfp_filenames,
+    get_feature_filenames,
+    get_label_filenames_from_feature_filenames,
+    get_lfp_chans_filenames,
+    get_feature_label_filenames,
+    get_weights,
+    unsqueeze_triangular_array,
+    squeeze_triangular_array,
+    get_outlier_summary,
+    flatten_dir_spec_features,
+    confusion_matrix,
+)
 
 from .utils.viterbi import top_k_viterbi, get_label_stats
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/models/__init__.py
+++ b/lpne/models/__init__.py
@@ -3,11 +3,15 @@ lpne.models
 
 """
 
-from .factor_analysis_sae import FaSae
-
 from .cp_sae import CpSae
 
+from .dcsfa_nmf import DcsfaNmf
+
+from .factor_analysis_sae import FaSae
+
 from .grid_search_cv import GridSearchCV
+
+from .nmf_base import NmfBase
 
 
 if __name__ == "__main__":

--- a/lpne/models/__init__.py
+++ b/lpne/models/__init__.py
@@ -10,10 +10,8 @@ from .cp_sae import CpSae
 from .grid_search_cv import GridSearchCV
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/models/base_model.py
+++ b/lpne/models/base_model.py
@@ -21,12 +21,10 @@ FLOAT = torch.float32
 INT = torch.int64
 
 
-
 class BaseModel(torch.nn.Module):
-
-    def __init__(self, n_iter=50000, batch_size=256, lr=1e-3, device='auto'):
+    def __init__(self, n_iter=50000, batch_size=256, lr=1e-3, device="auto"):
         """
-        
+
         Parameters
         ----------
         n_iter : int, optional
@@ -43,11 +41,10 @@ class BaseModel(torch.nn.Module):
         self.batch_size = batch_size
         self.lr = lr
         self.device = device
-        if self.device == 'auto':
-            self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        if self.device == "auto":
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.classes_ = None
         self.groups_ = None
-
 
     def _initialize(self):
         self.n_groups = len(self.groups_)
@@ -55,11 +52,10 @@ class BaseModel(torch.nn.Module):
         self.to(self.device)
         self.iter_ = 1
 
-
     def fit(self, features, labels, groups=None, print_freq=5, score_freq=5):
         """
         Train the model on the given dataset.
-        
+
         Parameters
         ----------
         features : numpy.ndarray
@@ -84,7 +80,7 @@ class BaseModel(torch.nn.Module):
         assert groups.ndim == 1
         assert len(features) == len(labels) and len(labels) == len(groups)
         # Remove missing data.
-        axes = tuple(i for i in range(1,features.ndim))
+        axes = tuple(i for i in range(1, features.ndim))
         idx = np.argwhere(np.isnan(features).sum(axis=axes) == 0).flatten()
         features = features[idx]
         labels = labels[idx]
@@ -117,9 +113,9 @@ class BaseModel(torch.nn.Module):
         # Make a Dataset, a DataLoader, and an optimizer.
         dset = TensorDataset(features, labels, groups, weights)
         loader = DataLoader(
-                dset,
-                batch_size=self.batch_size,
-                shuffle=True,
+            dset,
+            batch_size=self.batch_size,
+            shuffle=True,
         )
         optimizer = torch.optim.Adam(self.parameters(), lr=self.lr)
         # Train.
@@ -135,20 +131,19 @@ class BaseModel(torch.nn.Module):
                 print(f"iter {self.iter_:04d}, loss: {i_loss:3f}")
             if score_freq is not None and self.iter_ % score_freq == 0:
                 weighted_acc = self.score(
-                        features[idx_comp],
-                        np_labels[idx_comp],
-                        np_groups[idx_comp],
+                    features[idx_comp],
+                    np_labels[idx_comp],
+                    np_groups[idx_comp],
                 )
                 print(f"iter {self.iter_:04d}, acc: {weighted_acc:3f}")
             self.iter_ += 1
         return self
 
-
     @torch.no_grad()
     def reconstruct(self, features):
         """
         Reconstruct the features by sending them round trip through the model.
-        
+
         Parameters
         ----------
         features : numpy.ndarray
@@ -160,8 +155,8 @@ class BaseModel(torch.nn.Module):
             Shape: same as ``features``
         """
         check_is_fitted(self, attributes=self.FIT_ATTRIBUTES)
-        assert features.ndim in [2,4]
-        flag = (features.ndim == 4)
+        assert features.ndim in [2, 4]
+        flag = features.ndim == 4
         if flag:
             assert features.shape[2] == features.shape[3]
             orig_shape = features.shape
@@ -169,7 +164,7 @@ class BaseModel(torch.nn.Module):
         rec_features = []
         i = 0
         while i <= len(features):
-            batch_f = features[i:i+self.batch_size]
+            batch_f = features[i : i + self.batch_size]
             batch_f = torch.tensor(batch_f).to(self.device, FLOAT)
             batch_zs = self.get_latents(batch_f)
             batch_rec = self.project_latents(batch_zs)
@@ -179,7 +174,6 @@ class BaseModel(torch.nn.Module):
         if flag:
             return rec_features.reshape(orig_shape)
         return rec_features
-
 
     def get_params(self, deep=True):
         """Get the parameters of this estimator."""
@@ -192,28 +186,38 @@ class BaseModel(torch.nn.Module):
             __version__=LPNE_VERSION,
         )
         try:
-            params['classes_'] = self.classes_
-            params['groups_'] = self.groups_
-            params['iter_'] = self.iter_
-            params['features_shape_'] = self.features_shape_
+            params["classes_"] = self.classes_
+            params["groups_"] = self.groups_
+            params["iter_"] = self.iter_
+            params["features_shape_"] = self.features_shape_
         except:
             pass
         if deep:
             state_dict = self.state_dict()
             if len(state_dict) > 0:
                 for key in state_dict:
-                    state_dict[key] = state_dict[key].to('cpu')
-                params['state_dict'] = state_dict
+                    state_dict[key] = state_dict[key].to("cpu")
+                params["state_dict"] = state_dict
             try:
-                params['optimizer_state_dict'] = self.optimizer_.state_dict()
+                params["optimizer_state_dict"] = self.optimizer_.state_dict()
             except:
                 pass
         return params
 
-
-    def set_params(self, batch_size=None, lr=None, n_iter=None, device=None,
-        classes_=None, groups_=None, iter_=None, features_shape_=None,
-        state_dict=None, optimizer_state_dict=None, **kwargs):
+    def set_params(
+        self,
+        batch_size=None,
+        lr=None,
+        n_iter=None,
+        device=None,
+        classes_=None,
+        groups_=None,
+        iter_=None,
+        features_shape_=None,
+        state_dict=None,
+        optimizer_state_dict=None,
+        **kwargs,
+    ):
         """Set the parameters of this estimator."""
         if batch_size is not None:
             self.batch_size = batch_size
@@ -222,9 +226,9 @@ class BaseModel(torch.nn.Module):
         if n_iter is not None:
             self.n_iter = n_iter
         if device is not None:
-            if (not torch.cuda.is_available()) and device != 'cpu':
-                warnings.warn('Loading GPU-trained model as a CPU model.')
-                self.device = 'cpu'
+            if (not torch.cuda.is_available()) and device != "cpu":
+                warnings.warn("Loading GPU-trained model as a CPU model.")
+                self.device = "cpu"
             else:
                 self.device = device
         if features_shape_ is not None:
@@ -243,28 +247,26 @@ class BaseModel(torch.nn.Module):
                 self.optimizer_.load_state_dict(optimizer_state_dict)
         return self
 
-
     @torch.no_grad()
     def save_state(self, fn):
         """Save parameters for this estimator."""
         params = self.get_params(deep=True)
         np.save(fn, params)
 
-
     @torch.no_grad()
     def load_state(self, fn):
         """Load and set the parameters for this estimator."""
         d = np.load(fn, allow_pickle=True).item()
-        if 'model_name' in d:
-            assert d['model_name'] == self.MODEL_NAME, \
-                f"Expected {self.MODEL_NAME}, found {d['model_name']}"
+        if "model_name" in d:
+            assert (
+                d["model_name"] == self.MODEL_NAME
+            ), f"Expected {self.MODEL_NAME}, found {d['model_name']}"
         else:
             warnings.warn("Didn't find field model_name when loading model.")
         self.set_params(**d)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
 
 

--- a/lpne/models/dcsfa_nmf.py
+++ b/lpne/models/dcsfa_nmf.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 import warnings
 
 
-from .nmf_base_model import NmfBase
+from .nmf_base import NmfBase
 
 
 class DcsfaNmf(NmfBase):

--- a/lpne/models/dcsfa_nmf.py
+++ b/lpne/models/dcsfa_nmf.py
@@ -1,211 +1,334 @@
+"""
+Hunter's supervised autoencoder model
+
+"""
+__date__ = "September 2022"
+
+
+import numpy as np
+from sklearn.metrics import roc_auc_score
 import torch
 import torch.nn as nn
-import numpy as np
+import torch.nn.functional as F
+from torch.utils.data import TensorDataset, DataLoader, WeightedRandomSampler
 from tqdm import tqdm
-from torch.utils.data import TensorDataset, DataLoader
-from .nmf_base_model import NMF_Base
-from torch.utils.data import WeightedRandomSampler
-from sklearn.metrics import roc_auc_score
-from torchbd.loss import BetaDivLoss
 import warnings
 
+
+from .nmf_base_model import NMF_Base
+
+
+
 class dCSFA_NMF(NMF_Base):
-    def __init__(self,n_components,device='auto',n_intercepts=1,n_sup_networks=1,
-                optim_name='AdamW',recon_loss='MSE',recon_weight=1.0,sup_weight=1.0,sup_recon_weight=1.0,
-                useDeepEnc=True,h=256,sup_recon_type="Residual",feature_groups=None,group_weights=None,
-                fixed_corr=None,momentum=0.9,lr=1e-3,sup_smoothness_weight=1.0,saveFolder="~",verbose=False):
-        """dCSFA-NMF Encoder class that makes use of the nmf_base_class.
+    """
+    dCSFA-NMF model
 
-        Args:
-            n_components (int): number of networks to learn or latent dimensionality
-            device (str, optional): torch device in {"cuda","cpu","auto"}. Defaults to 'auto'.
-            n_intercepts (int, optional): Number of unique intercepts for logistic regression 
-                (sometimes mouse specific intercept is helpful). Defaults to 1.
-            n_sup_networks (int, optional): Number of networks that will be supervised (0 < n_sup_networks < n_components). Defaults to 1.
-            optim_name (str, optional): torch.optim algorithm to use in {"SGD","Adam","AdamW"}. Defaults to 'AdamW'.
-            recon_loss (str, optional): Reconstruction loss function in {"IS","MSE"}. Defaults to 'MSE'.
-            recon_weight (float, optional): Importance weight for the reconstruction. Defaults to 1.0.
-            sup_weight (float, optional): Importance weight for the supervision. Defaults to 1.0.
-            sup_recon_weight (float, optional): Importance weight for the reconstruction of the supervised component. Defaults to 1.0.
-            useDeepEnc (bool, optional): Whether to use a deep or linear encoder. Defaults to True.
-            h (int, optional): hidden layer size for the deep encoder. Defaults to 256.
-            sup_recon_type (str, optional): Which supervised component reconstruction loss to use in {"Residual","All"}. Defaults to "Residual".
-                "Residual" - Estimates network scores optimal for reconstruction and penalizes deviation of the real scores from those values
-                "All" - Evaluates the recon_loss of the supervised network reconstruction against all features. 
-            feature_groups (list of int, optional): Indices of the divisions of feature types. Defaults to None.
-            group_weights (list of floats, optional): Weights for each of the feature types. Defaults to None.
-            fixed_corr (list of str, optional): List the same length as n_sup_networks indicating correlation constraints for the network. Defaults to None.
-                "positive" - constrains a supervised network to have a positive correlation between score and label
-                "negative" - constrains a supervised network to have a negative correlation between score and label
-                "n/a" - no constraint is applied and the supervised network can be positive or negatively correlated. 
-            momentum (float, optional): momentum value if optimizer is "SGD". Defaults to 0.9.
-            lr (float, optional): learning rate for the optimizer. Defaults to 1e-3.
-            sup_smoothness_weight (float, optional): Encourages smoothness for the supervised network. Defaults to 1.0.
-            saveFolder (str, optional): Location to save the best pytorch model parameters. Defaults to "~".
-            verbose (bool, optional): Activates or deactivates print statements globally. Defaults to False.
-        """
-        super(dCSFA_NMF,self).__init__(n_components,device,n_sup_networks,fixed_corr,recon_loss,recon_weight,
-                sup_recon_type,sup_recon_weight,sup_smoothness_weight,feature_groups,group_weights,verbose)
+    Parameters
+    ----------
+    n_components : int, optional
+        number of networks to learn or latent dimensionality
+        NOTE: the sklearn convention is for all parameters to have default
+        values.
+    device : ``{'cuda','cpu','auto'}``, optional
+        Torch device. Defaults to ``'auto'``.
+    n_intercepts : int, optional
+        Number of unique intercepts for logistic regression 
+        (sometimes mouse specific intercept is helpful). Defaults to ``1``.
+        NOTE: can this be detected automatically, given a groups argument?
+    n_sup_networks : int, optional
+        Number of networks that will be supervised
+        ``0 < n_sup_networks < n_components``. Defaults to ``1``.
+    optim_name : ``{'SGD','Adam','AdamW'}``, optional
+        torch.optim algorithm to use in . Defaults to ``'AdamW'``.
+    recon_loss : ``{'IS', 'MSE'}``, optional
+        Reconstruction loss function. Defaults to ``'MSE'``.
+    recon_weight : float, optional
+        Importance weight for the reconstruction. Defaults to ``1.0``.
+    sup_weight : float, optional
+        Importance weight for the supervision. Defaults to ``1.0``.
+    sup_recon_weight : float, optional
+        Importance weight for the reconstruction of the supervised component.
+        Defaults to ``1.0``.
+    use_deep_encoder : bool, optional
+        NOTE: I've changed the name to use underscores
+        Whether to use a deep or linear encoder. Defaults to ``True``.
+    h : int, optional
+        Hidden layer size for the deep encoder. Defaults to ``256``.
+    sup_recon_type : ``{'Residual', 'All'}``, optional
+        Which supervised component reconstruction loss to use. Defaults to
+        ``'Residual'``. ``'Residual'`` estimates network scores optimal for
+        reconstruction and penalizes deviation of the real scores from those
+        values. ``'All'`` evaluates the reconstruction loss of the supervised
+        network reconstruction against all features. 
+    feature_groups : ``None`` or list of int, optional
+        Indices of the divisions of feature types. Defaults to ``None``.
+    group_weights : ``None`` or list of floats, optional
+        Weights for each of the feature types. Defaults to ``None``.
+    fixed_corr : ``None`` or list of str, optional
+        List the same length as ``n_sup_networks`` indicating correlation
+        constraints for the network. Defaults to ``None``. ``'positive'``
+        constrains a supervised network to have a positive correlation between
+        score and label. ``'negative'`` constrains a supervised network to have
+        a negative correlation between score and label. ``'n/a'`` applies no
+        constraint, meaning the supervised network can be positive or
+        negatively correlated. 
+    momentum : float, optional
+        Momentum value if optimizer is ``'SGD'``. Defaults to ``0.9``.
+    lr : float, optional
+        Learning rate for the optimizer. Defaults to ``1e-3``.
+    sup_smoothness_weight : float, optional
+        Encourages smoothness for the supervised network. Defaults to ``1.0``.
+    save_folder : str, optional
+        Location to save the best pytorch model parameters. Defaults to
+        ``'~'``. NOTE: this seems like a bad default. Maybe a ``save_filename``
+        parameter would be better.
+    verbose : bool, optional
+        Activates or deactivates print statements. Defaults to ``False``.
+    """
 
+    def __init__(self, n_components=32, device='auto', n_intercepts=1,
+        n_sup_networks=1, optim_name='AdamW', recon_loss='MSE',
+        recon_weight=1.0, sup_weight=1.0, sup_recon_weight=1.0,
+        use_deep_encoder=True, h=256, sup_recon_type="Residual",
+        feature_groups=None, group_weights=None, fixed_corr=None, momentum=0.9,
+        lr=1e-3, sup_smoothness_weight=1.0, save_folder='~', verbose=False):
+        """ """
+        super(dCSFA_NMF,self).__init__(
+                n_components,
+                device,
+                n_sup_networks,
+                fixed_corr,
+                recon_loss,
+                recon_weight,
+                sup_recon_type,
+                sup_recon_weight,
+                sup_smoothness_weight,
+                feature_groups,
+                group_weights,
+                verbose,
+        )
         self.n_intercepts = n_intercepts
         self.optim_name=optim_name
-        self.optim_alg = self.get_optim(optim_name) #definition in nmf_base_class
+        self.optim_alg = self.get_optim(optim_name)
         self.pred_loss_f = nn.BCELoss
         self.recon_weight = recon_weight
         self.sup_weight = sup_weight
-        self.useDeepEnc = useDeepEnc
+        self.use_deep_encoder = use_deep_encoder
         self.h = h
         self.momentum = momentum
         self.lr = lr
         self.sup_smoothness_weight = sup_smoothness_weight
-        self.saveFolder = saveFolder
-        print("Model parameters will be saved to directory: {}".format(saveFolder))
+        self.save_folder = save_folder
 
-    def _initialize(self,dim_in):
+
+    def _initialize(self, dim_in):
         """
         Initializes encoder and NMF parameters using the input dimensionality
 
-        Args:
-            dim_in (int): number of features (in total)
+        Parameters
+        ----------
+        dim_in : int
+            Total number of features
         """
-        self.dim_in = dim_in
-
-        self._initialize_NMF(dim_in) #definition in nmf_base_class
-
-        if self.useDeepEnc:
-            self.Encoder = nn.Sequential(nn.Linear(dim_in,self.h),
-                            nn.BatchNorm1d(self.h),
-                            nn.LeakyReLU(),
-                            nn.Linear(self.h,self.n_components),
-                            nn.Softplus(),
-                            )
-        
+        # NOTE: the sklearn convention is for attributes assigned after the
+        # __init__ function to have trailing underscores. It doesn't look like
+        # this attribute is every used, though, so maybe it should be removed.
+        self.dim_in_ = dim_in
+        # NOTE: I would change this to: super(dCSFA_NMF, self)._initialize()
+        # to make it more readable, renaming the _initialize_NMF to just
+        # _initialize.
+        self._initialize_NMF(dim_in)
+        if self.use_deep_encoder:
+            # NOTE: It's easier to read nested structures that look like this,
+            # with the closing parenthesis on the same level as the opening.
+            # NOTE: I've also changed Encoder to encoder to match conventions.
+            self.encoder = nn.Sequential(
+                    nn.Linear(dim_in, self.h),
+                    nn.BatchNorm1d(self.h),
+                    nn.LeakyReLU(),
+                    nn.Linear(self.h, self.n_components),
+                    nn.Softplus(),
+            )
         else:
-            self.Encoder_A = nn.Parameter(torch.randn(dim_in,self.n_components))
-            self.Encoder_b = nn.Parameter(torch.randn(self.n_components))
-
-        #Logistic Regression Parameters
+            # NOTE: this can also be a Sequential object too.
+            self.encoder = nn.Sequential(
+                    nn.Linear(dim_in, self.n_components),
+                    nn.Softplus(),
+            )
+        # Initialize logistic regression parameters.
+        # NOTE: these could larger torch tensors instead of lists.
         self.phi_list = nn.ParameterList([nn.Parameter(torch.randn(1)) for _ in range(self.n_sup_networks)])
         self.beta_list = nn.ParameterList([nn.Parameter(torch.randn(self.n_intercepts,1)) for _ in range(self.n_sup_networks)])
+        self.to(self.device)
 
-        self.to(self.device) #device set in nmf_base_class
 
     def instantiate_optimizer(self):
         """
-        Creates an optimizer object
+        Create an optimizer.
 
-        Returns:
-            optimizer (torch.optim): optimizer function with model parameters
+        Returns
+        -------
+        optimizer : torch.optim.Optimizer
+            Torch optimizer
         """
-        if self.optim_name == "SGD":
-            optimizer = self.optim_alg(self.parameters(),lr=self.lr,momentum=self.momentum)
+        if self.optim_name == 'SGD':
+            optimizer = self.optim_alg(
+                    self.parameters(),
+                    lr=self.lr,
+                    momentum=self.momentum,
+            )
         else:
             optimizer = self.optim_alg(self.parameters(),lr=self.lr)
         return optimizer
 
-    def get_all_class_predictions(self,X,s,intercept_mask,avgIntercept):
+
+    def get_all_class_predictions(self, X, s, intercept_mask, avg_intercept):
         """
-        get predictions for every supervised network
+        Get predictions for every supervised network.
 
-        Args:
-            X (torch.Tensor): Input Features
-                Shape: ``[batch_size,n_features]``
-            s (torch.Tensor): latent embeddings
-                Shape: ``[batch_size,n_components]``
-            intercept_mask (torch.Tensor): OneHot encoded mask for logistic regression intercept terms
-                Shape: ``[batch_size,n_intercepts]``
-            avgIntercept (bool): Whether to average all intercepts together
+        Parameters
+        ----------
+        X : torch.Tensor
+            Input features
+            Shape: ``[batch_size,n_features]``
+        s : torch.Tensor
+            latent embeddings
+            Shape: ``[batch_size,n_components]``
+        intercept_mask : torch.Tensor
+            One-hot encoded mask for logistic regression intercept terms
+            Shape: ``[batch_size,n_intercepts]``
+        avg_intercept : bool
+            Whether to average all intercepts together.
 
-        Returns:
-            y_pred_proba (torch.Tensor): predictions
-                Shape: ``[batch_size,n_sup_networks]``
+        Returns
+        -------
+        y_pred_proba : torch.Tensor
+            Predictions
+            Shape: ``[batch_size, n_sup_networks]``
         """
-        if intercept_mask is None and avgIntercept is False:
-            warnings.warn("Intercept mask cannot be none and avgIntercept False... Averaging Intercepts")
-            avgIntercept=True
-
-        #Get predictions for each class
+        if intercept_mask is None and avg_intercept is False:
+            warnings.warn(
+                f"Intercept mask cannot be none and avg_intercept False... " \
+                f"Averaging Intercepts",
+            )
+            avg_intercept=True
+        # Get predictions for each class.
+        # NOTE: it seems like this could be vectorized
         y_pred_list = []
         for sup_net in range(self.n_sup_networks):
-
             if self.n_intercepts == 1:
-                y_pred_proba = nn.Sigmoid()(s[:,sup_net].view(-1,1) * self.get_phi(sup_net) + self.beta_list[sup_net]).squeeze()
-            elif self.n_intercepts > 1 and not avgIntercept:
-                y_pred_proba = nn.Sigmoid()(s[:,sup_net].view(-1,1) * self.get_phi(sup_net) + intercept_mask @ self.beta_list[sup_net]).squeeze()
+                # NOTE: use torch.sigmoid instead of torch.nn.Sigmoid
+                # NOTE: squeeze() without a dimension argument could result in
+                # unexpected behavior if there's a batch dimension of 1
+                # somewhere.
+                y_pred_proba = torch.sigmoid(
+                    s[:,sup_net].view(-1,1) * self.get_phi(sup_net) \
+                    + self.beta_list[sup_net],
+                ).squeeze()
+            elif self.n_intercepts > 1 and not avg_intercept:
+                y_pred_proba = torch.sigmoid(
+                    s[:,sup_net].view(-1,1) * self.get_phi(sup_net) \
+                    + intercept_mask @ self.beta_list[sup_net],
+                ).squeeze()
             else:
                 intercept_mask = torch.ones(X.shape[0],self.n_intercepts).to(self.device) / self.n_intercepts
-                y_pred_proba = nn.Sigmoid()(s[:,sup_net].view(-1,1) * self.get_phi(sup_net) + intercept_mask @ self.beta_list[sup_net]).squeeze()
-
+                y_pred_proba = torch.sigmoid(s[:,sup_net].view(-1,1) * self.get_phi(sup_net) + intercept_mask @ self.beta_list[sup_net]).squeeze()
             y_pred_list.append(y_pred_proba.view(-1,1))
-
-        #Concatenate predictions into a single matrix [n_samples,n_tasks]
+        # Concatenate predictions into a single matrix [n_samples,n_tasks]
         y_pred_proba = torch.cat(y_pred_list,dim=1)
-
         return y_pred_proba
+
 
     def get_embedding(self,X):
         """
-        Forward pass of the encoder
+        Map features to latents
 
-        Args:
-            X (torch.Tensor): Input Features
-                Shape: ``[batch_size,n_features]``
+        Parameters
+        ----------
+        X : torch.Tensor
+            Input features
+            Shape: ``[batch_size,n_features]``
 
-        Returns:
-            s (torch.Tensor): latent embeddings (scores)
-                Shape: ``[batch_size,n_components]``
+        Returns
+        -------
+        s : torch.Tensor
+            Latent embeddings (scores)
+            Shape: ``[batch_size,n_components]``
         """
-        #Encode X using the deep or linear encoder
-        if self.useDeepEnc:
-            s = self.Encoder(X)
-        else:
-            s = nn.Softplus()(X @ self.Encoder_A + self.Encoder_b)
-        
-        return s
+        # NOTE: this is a one-liner because both encoders are Sequential
+        # objects
+        return self.encoder(X)
+    
 
-    def get_phi(self,sup_net=0):
+    def get_phi(self, sup_net=0):
         """
-        Returns the logistic regression coefficient constrained by chosen correlation.
+        Return the logistic regression coefficient correspoding to ``sup_net``.
 
-        Args:
-            sup_net (int, optional): Which supervised network you would like to get a coefficient for. Defaults to 0.
+        # NOTE: Raises before Parameters and Returns
 
-        Raises:
-            ValueError: If self.fixed_corr[sup_net] is not in {"n/a","positive","negative"}. This should be caught at initialization.
+        Raises
+        ------
+        * ``ValueError`` if ``self.fixed_corr[sup_net]`` is not in
+          ``{'n/a', 'positive', 'negative'}``. This should be caught at
+          initialization. # NOTE: it's better to catch this a initialization.
 
-        Returns:
-            phi (torch.Tensor): the coefficient that has either been returned raw, or through a positive or negative softplus(phi).
+        Parameters
+        ----------
+        sup_net : int, optional
+            Which supervised network you would like to get a coefficient for.
+            Defaults to ``0``.
+
+        Returns
+        -------
+        phi : torch.Tensor
+            The coefficient that has either been returned raw, or through a
+            positive or negative softplus(phi).
         """
-        if self.fixed_corr[sup_net] == "n/a":
+        fixed_corr_str = self.fixed_corr[sup_net].lower()
+        if fixed_corr_str == 'n/a':
             return self.phi_list[sup_net]
-        elif self.fixed_corr[sup_net].lower() == "positive":
-            return nn.Softplus()(self.phi_list[sup_net])
-        elif self.fixed_corr[sup_net].lower() == "negative":
-            return -1*nn.Softplus()(self.phi_list[sup_net])
+        elif fixed_corr_str == 'positive':
+            # NOTE: use nn.functional instead of nn here.
+            return F.softplus(self.phi_list[sup_net])
+        elif fixed_corr_str == 'negative':
+            return -1 * F.softplus(self.phi_list[sup_net])
         else:
-            raise ValueError("Unsupported fixed_corr value")
+            # NOTE: spit out an informative error
+            raise ValueError(f"Unsupported fixed_corr value: {fixed_corr_str}")
 
 
-    def forward(self,X,y,task_mask,pred_weight,intercept_mask=None,avgIntercept=False):
+    def forward(self, X, y, task_mask, pred_weight, intercept_mask=None,
+        avg_intercept=False):
         """
         dCSFA-NMF forward pass
 
-        Args:
-            X (torch.Tensor): Input Features
-                Shape: ``[batch_size,n_features]``
-            y (torch.Tensor): ground truth labels
-                Shape: ``[batch_size,n_sup_networks]``
-            task_mask (torch.Tensor): per window mask for whether or not predictions should be counted
-                Shape: ``[batch_size,n_sup_networks]``
-            pred_weight (torch.Tensor): per window classification importance weighting
-                Shape: ``[batch_size,1]``
-            intercept_mask (torch.Tensor, optional): window specific intercept mask. Defaults to None.
-                Shape: ``[batch_size,n_intercepts]``
-            avgIntercept (bool, optional): Whether or not to average intercepts - used in evaluation. Defaults to False.
+        Parameters
+        ----------
+        X : torch.Tensor
+            Input Features
+            Shape: ``[batch_size,n_features]``
+        y : torch.Tensor
+            Ground truth labels
+            Shape: ``[batch_size,n_sup_networks]``
+        task_mask : torch.Tensor 
+            Per window mask for whether or not predictions should be counted
+            Shape: ``[batch_size,n_sup_networks]``
+        pred_weight : torch.Tensor 
+            Per window classification importance weighting
+            Shape: ``[batch_size,1]``
+        intercept_mask : ``None`` or torch.Tensor, optional 
+            Window specific intercept mask. Defaults to ``None``.
+            Shape: ``[batch_size,n_intercepts]``
+        avg_intercept : bool, optional 
+            Whether or not to average intercepts. This is used in evaluation.
+            Defaults to ``False``.
 
-        Returns:
-            recon_loss (torch.Tensor): recon_weight*full_recon_loss + sup_recon_weight*sup_recon_loss
-            pred_loss (torch.Tensor): sup_weight*BCELoss()
+        Returns
+        -------
+        recon_loss (torch.Tensor): 
+            ``recon_weight*full_recon_loss + sup_recon_weight*sup_recon_loss``
+        pred_loss (torch.Tensor): 
+            ``sup_weight * BCELoss()``
         """
         #Get the scores from the encoder
         s = self.get_embedding(X)
@@ -214,183 +337,257 @@ class dCSFA_NMF(NMF_Base):
         recon_loss = self.NMF_decoder_forward(X,s)
 
         #Get predictions
-        y_pred = self.get_all_class_predictions(X,s,intercept_mask,avgIntercept)
-        pred_loss = self.sup_weight*self.pred_loss_f(weight=pred_weight)(y_pred*task_mask,y*task_mask)
+        y_pred = self.get_all_class_predictions(
+                X,
+                s,
+                intercept_mask,
+                avg_intercept,
+        )
+        pred_loss_f = self.pred_loss_f(weight=pred_weight)
+        pred_loss = self.sup_weight * pred_loss_f(
+                y_pred * task_mask,
+                y * task_mask,
+        )
 
-        #recon loss and pred loss are left seperate so only recon_loss can be applied for
-        #encoder pretraining
+        # recon loss and pred loss are left seperate so only recon_loss can be
+        # applied for encoder pretraining
+        # NOTE: consider adding a ``pretraining`` parameter to this method
+        # instead of passing two losses.
         return recon_loss, pred_loss
 
+
     @torch.no_grad()
-    def transform(self,X,intercept_mask=None,avgIntercept=True,return_npy=True):
+    def transform(self, X, intercept_mask=None, avg_intercept=True,
+        return_npy=True):
         """
         Transform method to return reconstruction, predictions, and projections
 
-        Args:
-            X (torch.Tensor): Input Features
-                Shape: ``[batch_size,n_features]``
-            intercept_mask (torch.Tensor, optional): window specific intercept mask. Defaults to None.
-                Shape: ``[batch_size,n_intercepts]``
-            avgIntercept (bool, optional): Whether or not to average intercepts - used in evaluation. Defaults to False.
-            return_npy (bool, optional): Whether or not to convert to numpy arrays. Defaults to True.
+        Parameters
+        ----------
+        X (torch.Tensor): Input Features
+            Shape: ``[batch_size,n_features]``
+        intercept_mask (torch.Tensor, optional): window specific intercept
+            mask. Defaults to None.
+            Shape: ``[batch_size,n_intercepts]``
+        avg_intercept (bool, optional): Whether or not to average intercepts -
+            used in evaluation. Defaults to False.
+        return_npy (bool, optional): Whether or not to convert to numpy arrays.
+            Defaults to True.
 
-        Returns:
-            X_recon (torch.Tensor) : Full reconstruction of input features
-                Shape: ``[n_samples,n_features]``
-            y_pred (torch.Tensor) : All task predictions
-                Shape: ``[n_samples,n_sup_networks]``
-            s (torch.Tensor) : Network activation scores
-                Shape: ``[n_samples,n_components]``
+        Returns
+        -------
+        X_recon (torch.Tensor) : Full reconstruction of input features
+            Shape: ``[n_samples,n_features]``
+        y_pred (torch.Tensor) : All task predictions
+            Shape: ``[n_samples,n_sup_networks]``
+        s (torch.Tensor) : Network activation scores
+            Shape: ``[n_samples,n_components]``
         """
         if not torch.is_tensor(X):
             X = torch.Tensor(X).float().to(self.device)
 
         s = self.get_embedding(X)
         X_recon = self.get_all_comp_recon(s)
-        y_pred = self.get_all_class_predictions(X,s,intercept_mask,avgIntercept)
-
+        y_pred = self.get_all_class_predictions(
+                X,
+                s,
+                intercept_mask,avg_intercept,
+        )
         if return_npy:
             s = s.detach().cpu().numpy()
             X_recon = X_recon.detach().cpu().numpy()
             y_pred = y_pred.detach().cpu().numpy()
-        
         return X_recon, y_pred, s
 
 
-    def pretrain_encoder(self,X,y,y_pred_weights,task_mask,intercept_mask,sample_weights,n_pre_epochs=100,batch_size=128):
+    def pretrain_encoder(self, X, y, y_pred_weights, task_mask, intercept_mask,
+        sample_weights, n_pre_epochs=100, batch_size=128):
         """
-        Pretrains the encoder to find a corresponding mapping to the pretrained NMF decoder
+        Pretrain the encoder.
 
-        Args:
-            X (torch.Tensor): Input Features
-                Shape: ``[n_samples,n_features]``
-            y (torch.Tensor): ground truth labels
-                Shape: ``[n_samples,n_sup_networks]``
-            task_mask (torch.Tensor): per window mask for whether or not predictions should be counted
-                Shape: ``[n_samples,n_sup_networks]``
-            y_pred_weight (torch.Tensor): per window classification importance weighting
-                Shape: ``[n_samples,1]``
-            intercept_mask (torch.Tensor, optional): window specific intercept mask. Defaults to None.
-                Shape: ``[n_samples,n_intercepts]``
-            sample_weights (torch.Tensor): Gradient Descent sampling weights.
-                Shape: ``[n_samples,1]
-            n_pre_epochs (int,optional): number of epochs for pretraining the encoder. Defaults to 100
-            batch_size (int,optional): batch size for pretraining. Defaults to 128
+        Parameters
+        ----------
+        X (torch.Tensor): Input Features
+            Shape: ``[n_samples,n_features]``
+        y (torch.Tensor): ground truth labels
+            Shape: ``[n_samples,n_sup_networks]``
+        task_mask (torch.Tensor): 
+            per window mask for whether or not predictions should be counted
+            Shape: ``[n_samples,n_sup_networks]``
+        y_pred_weight (torch.Tensor): 
+            per window classification importance weighting
+            Shape: ``[n_samples,1]``
+        intercept_mask (torch.Tensor, optional): 
+            window specific intercept mask. Defaults to None.
+            Shape: ``[n_samples,n_intercepts]``
+        sample_weights (torch.Tensor): 
+            Gradient Descent sampling weights.
+            Shape: ``[n_samples,1]
+        n_pre_epochs (int,optional): 
+            number of epochs for pretraining the encoder. Defaults to 100
+        batch_size (int,optional): 
+            batch size for pretraining. Defaults to 128
         """
-        #Freeze the decoder
+        # Freeze the decoder
         self.W_nmf.requires_grad = False
-
-        #Load arguments onto device
+        # Load arguments onto device
         X = torch.Tensor(X).float().to(self.device)
         y = torch.Tensor(y).float().to(self.device)
         y_pred_weights = torch.Tensor(y_pred_weights).float().to(self.device)
         task_mask = torch.Tensor(task_mask).long().to(self.device)
         intercept_mask = torch.Tensor(intercept_mask).to(self.device)
         sample_weights = torch.Tensor(sample_weights).to(self.device)
-
-        #create a dset
-        dset = TensorDataset(X,y,y_pred_weights,task_mask,intercept_mask)
-        sampler = WeightedRandomSampler(sample_weights,len(sample_weights))
-        loader = DataLoader(dset,batch_size=batch_size,sampler=sampler)
-
-        #Instantiate Optimizer
+        # Create a Dataset.
+        # dset = TensorDataset(X,y,y_pred_weights,task_mask,intercept_mask)
+        # NOTE: I changed the order to match ``self.forward``
+        dset = TensorDataset(X, y, task_mask, y_pred_weights, intercept_mask)
+        sampler = WeightedRandomSampler(sample_weights, len(sample_weights))
+        loader = DataLoader(dset, batch_size=batch_size, sampler=sampler)
+        # Instantiate Optimizer
         optimizer = self.instantiate_optimizer()
-
         #Define iterator
         if self.verbose:
             epoch_iter = tqdm(range(n_pre_epochs))
         else:
             epoch_iter = range(n_pre_epochs)
-
         for epoch in epoch_iter:
             r_loss = 0.0
-            for X_batch,y_batch,y_pred_weights_batch,task_mask_batch,intercept_mask_batch in loader:
+            # NOTE: don't unpack everything if you don't need to:
+            for batch in loader:
                 optimizer.zero_grad()
-                recon_loss,_ = self.forward(X_batch,y_batch,task_mask_batch,y_pred_weights_batch,intercept_mask_batch)
+                recon_loss,_ = self.forward(*batch)
                 recon_loss.backward()
                 optimizer.step()
                 r_loss += recon_loss.item()
-            
             if self.verbose:
-                epoch_iter.set_description("Encoder Pretrain Epoch: {}, Recon Loss: {:.6}".format(epoch,r_loss/len(loader)))
-
-        #Unfreeze the NMF decoder
+                # NOTE: python f-strings are more concise than ``.format``
+                avg_r = r_loss / len(loader)
+                epoch_iter.set_description(
+                    f"Encoder Pretrain Epoch: {epoch}, Recon Loss: {avg_r:.6}",
+                )
+        # Unfreeze the NMF decoder.
         self.W_nmf.requires_grad = True
 
-    def fit(self,X,y,y_pred_weights=None,task_mask=None,intercept_mask=None,y_sample_groups=None,n_epochs=100,n_pre_epochs=100,nmf_max_iter=100,
-            batch_size=128,lr=1e-3,pretrain=True,verbose=False,X_val=None,y_val=None,y_pred_weights_val=None,task_mask_val=None,
-            best_model_name="dCSFA-NMF-best-model.pt"):
-        """
-        fit the model
 
-        Args:
-            X (np.ndarray): Input Features
-                Shape: ``[n_samples, n_features]``
-            y (np.ndarray): ground truth labels
-                Shape: ``[n_samples, n_sup_networks]``
-            y_pred_weights (np.ndarray, optional): supervision window specific importance weights. Defaults to None.
-                Shape: ``[n_samples,1]``
-            task_mask (np.ndarray, optional): identifies which windows should be trained on which tasks. Defaults to None.
-                Shape: ``[n_samples,n_sup_networks]``
-            intercept_mask (np.ndarray, optional): One-Hot Mask for group specific intercepts in the logistic regression model. Defaults to None.
-                Shape: ``[n_samples,n_intercepts]``
-            y_sample_groups (_type_, optional): groups for creating sample weights - each group will be sampled evenly. Defaults to None.
-                Shape: ``[n_samples,1]``
-            n_epochs (int, optional): number of training epochs. Defaults to 100.
-            n_pre_epochs (int, optional): number of pretraining epochs. Defaults to 100.
-            nmf_max_iter (int, optional): max iterations for NMF pretraining solver. Defaults to 100.
-            batch_size (int, optional): batch size for gradient descent. Defaults to 128.
-            lr (_type_, optional): learning rate for gradient descent. Defaults to 1e-3.
-            pretrain (bool, optional): whether or not to pretrain the generative model. Defaults to True.
-            verbose (bool, optional): activate or deactivate print statements. Defaults to False.
-            X_val (np.ndarray, optional): Validation Features for checkpointing. Defaults to None.
-                Shape: ``[n_val_samples,n_features]``
-            y_val (np.ndarray, optional): Validation Labels for checkpointing. Defaults to None.
-                Shape: ``[n_val_samples,n_sup_networks]``
-            y_pred_weights_val (np.ndarray, optional): window specific classification weights. Defaults to None.
-                Shape: ``[n_val_samples,1]``
-            task_mask_val (np.ndarray, optional): validation task relevant window masking. Defaults to None.
-                Shape: ``[n_val_samples,n_sup_networks]``
-            best_model_name (str, optional): save file name for the best model. Must end in ".pt". Defaults to "dCSFA-NMF-best-model.pt".
+    def fit(self, X, y, y_pred_weights=None, task_mask=None,
+        intercept_mask=None, y_sample_groups=None, n_epochs=100,
+        n_pre_epochs=100, nmf_max_iter=100, batch_size=128, lr=1e-3,
+        pretrain=True, verbose=False, X_val=None, y_val=None,
+        y_pred_weights_val=None, task_mask_val=None,
+        best_model_name="dCSFA-NMF-best-model.pt"):
         """
-        #Initialize model parameters
+        Fit the model.
+
+        NOTE: isn't ``lr`` a model parameter? epochs and pre epochs could be
+        too.
+
+        Parameters
+        ----------
+        X (np.ndarray): Input Features
+            Shape: ``[n_samples, n_features]``
+        y (np.ndarray): ground truth labels
+            Shape: ``[n_samples, n_sup_networks]``
+        y_pred_weights (np.ndarray, optional): 
+            supervision window specific importance weights. Defaults to
+            ``None``.
+            Shape: ``[n_samples,1]``
+        task_mask (np.ndarray, optional): 
+            identifies which windows should be trained on which tasks. Defaults
+            to ``None``.
+            Shape: ``[n_samples,n_sup_networks]``
+        intercept_mask (np.ndarray, optional): 
+            One-hot Mask for group specific intercepts in the logistic
+            regression model. Defaults to None.
+            Shape: ``[n_samples,n_intercepts]``
+        y_sample_groups (_type_, optional): 
+            groups for creating sample weights - each group will be sampled
+            evenly. Defaults to None.
+            Shape: ``[n_samples,1]``
+        n_epochs (int, optional): 
+            number of training epochs. Defaults to 100.
+        n_pre_epochs (int, optional): 
+            number of pretraining epochs. Defaults to 100.
+        nmf_max_iter (int, optional): 
+            max iterations for NMF pretraining solver. Defaults to 100.
+        batch_size (int, optional): 
+            batch size for gradient descent. Defaults to 128.
+        lr (_type_, optional): 
+            learning rate for gradient descent. Defaults to 1e-3.
+        pretrain (bool, optional): 
+            whether or not to pretrain the generative model. Defaults to True.
+        verbose (bool, optional): 
+            activate or deactivate print statements. Defaults to False.
+        X_val (np.ndarray, optional): 
+            Validation Features for checkpointing. Defaults to None.
+            Shape: ``[n_val_samples,n_features]``
+        y_val (np.ndarray, optional): 
+            Validation Labels for checkpointing. Defaults to None.
+            Shape: ``[n_val_samples,n_sup_networks]``
+        y_pred_weights_val (np.ndarray, optional): 
+            window specific classification weights. Defaults to None.
+            Shape: ``[n_val_samples,1]``
+        task_mask_val (np.ndarray, optional): 
+            validation task relevant window masking. Defaults to None.
+            Shape: ``[n_val_samples,n_sup_networks]``
+        best_model_name (str, optional): 
+            save file name for the best model. Must end in ".pt". Defaults to
+            ``'dCSFA-NMF-best-model.pt'``.
+
+        Returns
+        -------
+        self : dCSFA_NMF
+            The fitted model. NOTE: sklearn convention
+        """
+        # Initialize model parameters.
         self._initialize(X.shape[1])
 
-        #establish loss histories
-        self.training_hist = [] #tracks average overall loss value during training
-        self.recon_hist = [] #tracks training data mse
-        self.pred_hist = [] #tracks training data aucs
+        # Establish loss histories.
+        self.training_hist = [] # tracks average overall loss
+        self.recon_hist = [] # tracks training data mse
+        self.pred_hist = [] # tracks training data aucs
 
-        #Globaly activate/deactivate print statements
+        # Globaly activate/deactivate print statements.
         self.verbose=verbose
         self.lr = lr
 
-        #Fill default values
+        # Fill default values
         if intercept_mask is None:
             intercept_mask = np.ones((X.shape[0],self.n_intercepts))
-
         if task_mask is None:
             task_mask = np.ones(y.shape)
-
         if y_pred_weights is None:
             y_pred_weights = np.ones((y.shape[0],1))
 
-        #Fill sampler parameters
+        # Fill sampler parameters.
         if y_sample_groups is None:
             y_sample_groups = np.ones((y.shape[0]))
             samples_weights = y_sample_groups
         else:
-            class_sample_counts = np.array([np.sum(y_sample_groups==group) for group in np.unique(y_sample_groups)])
+            class_sample_counts = np.array(
+                    [np.sum(y_sample_groups==group) \
+                    for group in np.unique(y_sample_groups)],
+            )
             weight = 1. / class_sample_counts
-            samples_weights = np.array([weight[t] for t in y_sample_groups.astype(int)]).squeeze()
+            samples_weights = np.array(
+                    [weight[t] for t in y_sample_groups.astype(int)],
+            ).squeeze()
             samples_weights = torch.Tensor(samples_weights)
 
-        #Pretrain the model
+        # Pretrain the model.
         if pretrain:
-            self.pretrain_NMF(X,y,nmf_max_iter)
-            self.pretrain_encoder(X,y,y_pred_weights,task_mask,intercept_mask,samples_weights,n_pre_epochs,batch_size)
+            self.pretrain_NMF(X, y, nmf_max_iter)
+            self.pretrain_encoder(
+                    X,
+                    y,
+                    y_pred_weights,
+                    task_mask,
+                    intercept_mask,
+                    samples_weights,
+                    n_pre_epochs,
+                    batch_size,
+            )
             
-        #Send Training Arguments to Tensors
+        # Send training arguments to Tensors.
         X = torch.Tensor(X).float().to(self.device)
         y = torch.Tensor(y).float().to(self.device)
         y_pred_weights = torch.Tensor(y_pred_weights).float().to(self.device)
@@ -398,9 +595,11 @@ class dCSFA_NMF(NMF_Base):
         intercept_mask = torch.Tensor(intercept_mask).long().to(self.device)
         samples_weights = torch.Tensor(samples_weights).to(self.device)
 
-        #If validation data is provided, set up the tensors
+        # If validation data is provided, set up the tensors.
         if X_val is not None and y_val is not None:
-            assert best_model_name.split('.')[-1] == "pt", f"Save file `{self.saveFolder + best_model_name}` must be of type .pt"
+            assert best_model_name.split('.')[-1] == "pt", \
+                f"Save file `{self.save_folder + best_model_name}` must be " \
+                f"of type .pt"
             self.best_model_name = best_model_name
             self.best_val_recon = 1e8
             self.best_val_avg_auc = 0.0
@@ -416,75 +615,101 @@ class dCSFA_NMF(NMF_Base):
             X_val = torch.Tensor(X_val).float().to(self.device)
             y_val = torch.Tensor(y_val).float().to(self.device)
             task_mask_val = torch.Tensor(task_mask_val).long().to(self.device)
-            y_pred_weights_val = torch.Tensor(y_pred_weights_val).float().to(self.device)
+            y_pred_weights_val = torch.Tensor(
+                    y_pred_weights_val,
+            ).float().to(self.device)
 
 
-        #Instantiate the dataloader and optimizer
-        dset = TensorDataset(X,y,y_pred_weights,task_mask,intercept_mask)
-        sampler = WeightedRandomSampler(samples_weights,len(samples_weights))
+        # Instantiate the dataloader and optimizer.
+        dset = TensorDataset(X, y, task_mask, y_pred_weights, intercept_mask)
+        sampler = WeightedRandomSampler(samples_weights, len(samples_weights))
         loader = DataLoader(dset,batch_size=batch_size,sampler=sampler)
         optimizer = self.instantiate_optimizer()
 
-        #Define Training Iterator
+        # Define the training iterator.
         if self.verbose: 
             print("Beginning Training")
             epoch_iter = tqdm(range(n_epochs))
         else:
             epoch_iter = range(n_epochs)
 
-        #Training Loop
+        # Training loop.
         for epoch in epoch_iter:
             epoch_loss = 0.0
             recon_e_loss = 0.0
             pred_e_loss = 0.0
 
-            for X_batch,y_batch,y_pred_weights_batch,task_mask_batch,intercept_mask_batch in loader:
-
+            for batch in loader:
                 self.train()
                 optimizer.zero_grad()
-                recon_loss, pred_loss = self.forward(X_batch,y_batch,task_mask_batch,y_pred_weights_batch,intercept_mask_batch)
-                loss = recon_loss + pred_loss #Weighting happens inside of the forward call
+                recon_loss, pred_loss = self.forward(*batch)
+                # Weighting happens inside of the forward call
+                loss = recon_loss + pred_loss
                 loss.backward()
                 optimizer.step()
-
                 epoch_loss += loss.item()
                 recon_e_loss += recon_loss.item()
                 pred_e_loss += pred_loss.item()
-
             self.training_hist.append(epoch_loss / len(loader))
             with torch.no_grad():
                 self.eval()
-                X_recon, y_pred, s = self.transform(X,y,intercept_mask,return_npy=False)
+                X_recon, y_pred, _ = self.transform(
+                        X,
+                        y,
+                        intercept_mask,
+                        return_npy=False,
+                )
                 training_mse_loss = nn.MSELoss()(X_recon,X).item()
                 training_auc_list = []
                 for sup_net in range(self.n_sup_networks):
-                    auc = roc_auc_score(y.detach().cpu().numpy()[task_mask[:,sup_net].detach().cpu().numpy()==1,sup_net],
-                                        y_pred.detach().cpu().numpy()[task_mask[:,sup_net].detach().cpu().numpy()==1,sup_net])
+                    temp_mask = task_mask[:,sup_net].detach().cpu().numpy()
+                    auc = roc_auc_score(
+                        y.detach().cpu().numpy()[temp_mask==1,sup_net],
+                        y_pred.detach().cpu().numpy()[temp_mask==1,sup_net],
+                    )
                     training_auc_list.append(auc)
-                
                 self.recon_hist.append(training_mse_loss)
                 self.pred_hist.append(training_auc_list)
 
-                #If Validation data is present, collect performance metrics
+                # If validation data is present, collect performance metrics.
                 if X_val is not None and y_val is not None:
-                    X_recon_val,y_pred_val,s_val = self.transform(X_val,y_val,return_npy=False)
-                    validation_mse_loss = nn.MSELoss()(X_recon_val,X_val).item()
+                    X_recon_val, y_pred_val, _ = self.transform(
+                            X_val,
+                            y_val,
+                            return_npy=False,
+                    )
+                    validation_mse_loss = nn.MSELoss()(
+                            X_recon_val,
+                            X_val,
+                    ).item()
                     validation_auc_list = []
                     for sup_net in range(self.n_sup_networks):
-                        auc = roc_auc_score(y_val.detach().cpu().numpy()[task_mask_val[:,sup_net].detach().cpu().numpy()==1,sup_net],
-                                            y_pred_val.detach().cpu().numpy()[task_mask_val[:,sup_net].detach().cpu().numpy()==1,sup_net])
+                        temp_mask = task_mask_val[:,sup_net].detach().cpu().numpy()
+                        auc = roc_auc_score(
+                            y_val.detach().cpu().numpy()[temp_mask==1,sup_net],
+                            y_pred_val.detach().cpu().numpy()[temp_mask==1,sup_net],
+                        )
                         validation_auc_list.append(auc)
                     
                     self.val_recon_hist.append(validation_mse_loss)
                     self.val_pred_hist.append(validation_auc_list)
 
-                    if validation_mse_loss < self.best_val_recon and np.mean(validation_auc_list) > self.best_val_avg_auc:
+                    cond_1 = validation_mse_loss < self.best_val_recon
+                    cond_2 = np.mean(validation_auc_list) > self.best_val_avg_auc
+
+                    if  cond_1 and cond_2:
                         self.best_epoch = epoch
                         self.best_val_recon = validation_mse_loss
                         self.best_val_aucs = validation_auc_list
-                        torch.save(self.state_dict(),self.saveFolder + self.best_model_name)
+                        # NOTE: os.path.join does this a bit better:
+                        torch.save(
+                                self.state_dict(),
+                                self.save_folder + self.best_model_name,
+                        )
 
                     if self.verbose:
+                        # NOTE: this string can be defined in the file header
+                        # to save some space.
                         epoch_iter.set_description("Epoch: {}, Best Epoch: {}, Best Val MSE: {:.6}, Best Val by Window ROC-AUC {}, current MSE: {:.6}, current AUC: {}".format(epoch,
                                                                                                                                                                         self.best_epoch,
                                                                                                                                                                         self.best_val_recon,
@@ -492,35 +717,50 @@ class dCSFA_NMF(NMF_Base):
                                                                                                                                                                         validation_mse_loss,
                                                                                                                                                                         validation_auc_list))
                 else:
+                    # NOTE: ssame here
                     epoch_iter.set_description("Epoch: {}, Current Training MSE: {:.6}, Current Training by Window ROC-AUC: {}".format(epoch,training_mse_loss,training_auc_list))
         
         if self.verbose:
             print("Saving the last epoch with training MSE: {:.6} and AUCs:{}".format(training_mse_loss,training_auc_list))
-        torch.save(self.state_dict(),self.saveFolder + "dCSFA-NMF-last-epoch.pt") #Last epoch is saved in case the saved 'best model' doesn't make sense
+        # Last epoch is saved in case the saved 'best model' doesn't make sense
+        # NOTE: is this necessary?
+        torch.save(
+                self.state_dict(),
+                self.save_folder + "dCSFA-NMF-last-epoch.pt",
+        )
         
         if X_val is not None and y_val is not None:
             if self.verbose:
                 print("Loaded the best model from Epoch: {} with MSE: {:.6} and AUCs: {}".format(self.best_epoch,self.best_val_recon,self.best_val_aucs))
-            self.load_state_dict(torch.load(self.saveFolder+self.best_model_name))
+            self.load_state_dict(torch.load(self.save_folder+self.best_model_name))
+        return self
+
 
     def load_last_epoch(self):
         """
-        Loads model parameters of the last epoch in case the last epoch is preferable to the early stop
-        checkpoint conditions. This will be visible in the training printout if self.verbose=True
+        Loads model parameters of the last epoch in case the last epoch is
+        preferable to the early stop checkpoint conditions. This will be
+        visible in the training printout if self.verbose=True
         """
-        self.load_state_dict(torch.load(self.saveFolder + "dCSFA-NMF-last-epoch.pt"))
+        self.load_state_dict(
+            torch.load(self.save_folder + "dCSFA-NMF-last-epoch.pt"),
+        )
+
 
     def reconstruct(self,X,component=None):
         """
         Gets full or partial reconstruction.
 
-        Args:
-            X (numpy.ndarray): Input Features
-                Shape: ``[n_samples,n_features]``
-            component (int,optional):identifies which component to use for reconstruction
+        Parameters
+        ----------
+        X (numpy.ndarray): Input Features
+            Shape: ``[n_samples,n_features]``
+        component (int,optional):
+            identifies which component to use for reconstruction
 
-        Returns:
-            X_recon: Full recon if component=None, else, recon for network[comopnent]
+        Returns
+        -------
+        X_recon: Full recon if component=None, else, recon for network[comopnent]
         """
         X_recon,_,s = self.transform(X)
 
@@ -529,19 +769,25 @@ class dCSFA_NMF(NMF_Base):
 
         return X_recon
 
+
     def predict_proba(self,X,return_scores=False):
         """
         Returns prediction probabilities
-        Args:
-            X (numpy.ndarray): Input Features
-                Shape: ``[n_samples,n_features]``
-            return_scores (bool, optional): Whether or not to include the projections. Defaults to False.
+        
+        Parameters
+        ----------
+        X (numpy.ndarray):
+            Input Features
+            Shape: ``[n_samples,n_features]``
+        return_scores (bool, optional):
+            Whether or not to include the projections. Defaults to False.
 
-        Returns:
-            y_pred_proba (numpy.ndarray): predictions
-                Shape: ``[n_samples,n_sup_networks]``
-            s (numpy.ndarray): supervised network activation scores
-                Shape: ``[n_samples,n_components]
+        Returns
+        -------
+        y_pred_proba (numpy.ndarray): predictions
+            Shape: ``[n_samples,n_sup_networks]``
+        s (numpy.ndarray): supervised network activation scores
+            Shape: ``[n_samples,n_components]
         """
         _,y_pred,s = self.transform(X)
 
@@ -549,6 +795,7 @@ class dCSFA_NMF(NMF_Base):
             return y_pred, s
         else:
             return y_pred
+
 
     def predict(self,X,return_scores=False):
         """
@@ -570,6 +817,7 @@ class dCSFA_NMF(NMF_Base):
         else:
             return y_pred > 0.5
 
+
     def project(self,X):
         """
         Get projections
@@ -585,6 +833,7 @@ class dCSFA_NMF(NMF_Base):
         """
         _,_,s = self.transform(X)
         return s
+
 
     def score(self,X,y,groups=None,return_dict=False):
         """
@@ -636,14 +885,8 @@ class dCSFA_NMF(NMF_Base):
 
 
 
+if __name__ == '__main__':
+    pass
 
 
-            
-
-
-
-
-
-
-
-        
+###     

--- a/lpne/models/dcsfa_nmf.py
+++ b/lpne/models/dcsfa_nmf.py
@@ -1,0 +1,649 @@
+import torch
+import torch.nn as nn
+import numpy as np
+from tqdm import tqdm
+from torch.utils.data import TensorDataset, DataLoader
+from .nmf_base_model import NMF_Base
+from torch.utils.data import WeightedRandomSampler
+from sklearn.metrics import roc_auc_score
+from torchbd.loss import BetaDivLoss
+import warnings
+
+class dCSFA_NMF(NMF_Base):
+    def __init__(self,n_components,device='auto',n_intercepts=1,n_sup_networks=1,
+                optim_name='AdamW',recon_loss='MSE',recon_weight=1.0,sup_weight=1.0,sup_recon_weight=1.0,
+                useDeepEnc=True,h=256,sup_recon_type="Residual",feature_groups=None,group_weights=None,
+                fixed_corr=None,momentum=0.9,lr=1e-3,sup_smoothness_weight=1.0,saveFolder="~",verbose=False):
+        """dCSFA-NMF Encoder class that makes use of the nmf_base_class.
+
+        Args:
+            n_components (int): number of networks to learn or latent dimensionality
+            device (str, optional): torch device in {"cuda","cpu","auto"}. Defaults to 'auto'.
+            n_intercepts (int, optional): Number of unique intercepts for logistic regression 
+                (sometimes mouse specific intercept is helpful). Defaults to 1.
+            n_sup_networks (int, optional): Number of networks that will be supervised (0 < n_sup_networks < n_components). Defaults to 1.
+            optim_name (str, optional): torch.optim algorithm to use in {"SGD","Adam","AdamW"}. Defaults to 'AdamW'.
+            recon_loss (str, optional): Reconstruction loss function in {"IS","MSE"}. Defaults to 'MSE'.
+            recon_weight (float, optional): Importance weight for the reconstruction. Defaults to 1.0.
+            sup_weight (float, optional): Importance weight for the supervision. Defaults to 1.0.
+            sup_recon_weight (float, optional): Importance weight for the reconstruction of the supervised component. Defaults to 1.0.
+            useDeepEnc (bool, optional): Whether to use a deep or linear encoder. Defaults to True.
+            h (int, optional): hidden layer size for the deep encoder. Defaults to 256.
+            sup_recon_type (str, optional): Which supervised component reconstruction loss to use in {"Residual","All"}. Defaults to "Residual".
+                "Residual" - Estimates network scores optimal for reconstruction and penalizes deviation of the real scores from those values
+                "All" - Evaluates the recon_loss of the supervised network reconstruction against all features. 
+            feature_groups (list of int, optional): Indices of the divisions of feature types. Defaults to None.
+            group_weights (list of floats, optional): Weights for each of the feature types. Defaults to None.
+            fixed_corr (list of str, optional): List the same length as n_sup_networks indicating correlation constraints for the network. Defaults to None.
+                "positive" - constrains a supervised network to have a positive correlation between score and label
+                "negative" - constrains a supervised network to have a negative correlation between score and label
+                "n/a" - no constraint is applied and the supervised network can be positive or negatively correlated. 
+            momentum (float, optional): momentum value if optimizer is "SGD". Defaults to 0.9.
+            lr (float, optional): learning rate for the optimizer. Defaults to 1e-3.
+            sup_smoothness_weight (float, optional): Encourages smoothness for the supervised network. Defaults to 1.0.
+            saveFolder (str, optional): Location to save the best pytorch model parameters. Defaults to "~".
+            verbose (bool, optional): Activates or deactivates print statements globally. Defaults to False.
+        """
+        super(dCSFA_NMF,self).__init__(n_components,device,n_sup_networks,fixed_corr,recon_loss,recon_weight,
+                sup_recon_type,sup_recon_weight,sup_smoothness_weight,feature_groups,group_weights,verbose)
+
+        self.n_intercepts = n_intercepts
+        self.optim_name=optim_name
+        self.optim_alg = self.get_optim(optim_name) #definition in nmf_base_class
+        self.pred_loss_f = nn.BCELoss
+        self.recon_weight = recon_weight
+        self.sup_weight = sup_weight
+        self.useDeepEnc = useDeepEnc
+        self.h = h
+        self.momentum = momentum
+        self.lr = lr
+        self.sup_smoothness_weight = sup_smoothness_weight
+        self.saveFolder = saveFolder
+        print("Model parameters will be saved to directory: {}".format(saveFolder))
+
+    def _initialize(self,dim_in):
+        """
+        Initializes encoder and NMF parameters using the input dimensionality
+
+        Args:
+            dim_in (int): number of features (in total)
+        """
+        self.dim_in = dim_in
+
+        self._initialize_NMF(dim_in) #definition in nmf_base_class
+
+        if self.useDeepEnc:
+            self.Encoder = nn.Sequential(nn.Linear(dim_in,self.h),
+                            nn.BatchNorm1d(self.h),
+                            nn.LeakyReLU(),
+                            nn.Linear(self.h,self.n_components),
+                            nn.Softplus(),
+                            )
+        
+        else:
+            self.Encoder_A = nn.Parameter(torch.randn(dim_in,self.n_components))
+            self.Encoder_b = nn.Parameter(torch.randn(self.n_components))
+
+        #Logistic Regression Parameters
+        self.phi_list = nn.ParameterList([nn.Parameter(torch.randn(1)) for _ in range(self.n_sup_networks)])
+        self.beta_list = nn.ParameterList([nn.Parameter(torch.randn(self.n_intercepts,1)) for _ in range(self.n_sup_networks)])
+
+        self.to(self.device) #device set in nmf_base_class
+
+    def instantiate_optimizer(self):
+        """
+        Creates an optimizer object
+
+        Returns:
+            optimizer (torch.optim): optimizer function with model parameters
+        """
+        if self.optim_name == "SGD":
+            optimizer = self.optim_alg(self.parameters(),lr=self.lr,momentum=self.momentum)
+        else:
+            optimizer = self.optim_alg(self.parameters(),lr=self.lr)
+        return optimizer
+
+    def get_all_class_predictions(self,X,s,intercept_mask,avgIntercept):
+        """
+        get predictions for every supervised network
+
+        Args:
+            X (torch.Tensor): Input Features
+                Shape: ``[batch_size,n_features]``
+            s (torch.Tensor): latent embeddings
+                Shape: ``[batch_size,n_components]``
+            intercept_mask (torch.Tensor): OneHot encoded mask for logistic regression intercept terms
+                Shape: ``[batch_size,n_intercepts]``
+            avgIntercept (bool): Whether to average all intercepts together
+
+        Returns:
+            y_pred_proba (torch.Tensor): predictions
+                Shape: ``[batch_size,n_sup_networks]``
+        """
+        if intercept_mask is None and avgIntercept is False:
+            warnings.warn("Intercept mask cannot be none and avgIntercept False... Averaging Intercepts")
+            avgIntercept=True
+
+        #Get predictions for each class
+        y_pred_list = []
+        for sup_net in range(self.n_sup_networks):
+
+            if self.n_intercepts == 1:
+                y_pred_proba = nn.Sigmoid()(s[:,sup_net].view(-1,1) * self.get_phi(sup_net) + self.beta_list[sup_net]).squeeze()
+            elif self.n_intercepts > 1 and not avgIntercept:
+                y_pred_proba = nn.Sigmoid()(s[:,sup_net].view(-1,1) * self.get_phi(sup_net) + intercept_mask @ self.beta_list[sup_net]).squeeze()
+            else:
+                intercept_mask = torch.ones(X.shape[0],self.n_intercepts).to(self.device) / self.n_intercepts
+                y_pred_proba = nn.Sigmoid()(s[:,sup_net].view(-1,1) * self.get_phi(sup_net) + intercept_mask @ self.beta_list[sup_net]).squeeze()
+
+            y_pred_list.append(y_pred_proba.view(-1,1))
+
+        #Concatenate predictions into a single matrix [n_samples,n_tasks]
+        y_pred_proba = torch.cat(y_pred_list,dim=1)
+
+        return y_pred_proba
+
+    def get_embedding(self,X):
+        """
+        Forward pass of the encoder
+
+        Args:
+            X (torch.Tensor): Input Features
+                Shape: ``[batch_size,n_features]``
+
+        Returns:
+            s (torch.Tensor): latent embeddings (scores)
+                Shape: ``[batch_size,n_components]``
+        """
+        #Encode X using the deep or linear encoder
+        if self.useDeepEnc:
+            s = self.Encoder(X)
+        else:
+            s = nn.Softplus()(X @ self.Encoder_A + self.Encoder_b)
+        
+        return s
+
+    def get_phi(self,sup_net=0):
+        """
+        Returns the logistic regression coefficient constrained by chosen correlation.
+
+        Args:
+            sup_net (int, optional): Which supervised network you would like to get a coefficient for. Defaults to 0.
+
+        Raises:
+            ValueError: If self.fixed_corr[sup_net] is not in {"n/a","positive","negative"}. This should be caught at initialization.
+
+        Returns:
+            phi (torch.Tensor): the coefficient that has either been returned raw, or through a positive or negative softplus(phi).
+        """
+        if self.fixed_corr[sup_net] == "n/a":
+            return self.phi_list[sup_net]
+        elif self.fixed_corr[sup_net].lower() == "positive":
+            return nn.Softplus()(self.phi_list[sup_net])
+        elif self.fixed_corr[sup_net].lower() == "negative":
+            return -1*nn.Softplus()(self.phi_list[sup_net])
+        else:
+            raise ValueError("Unsupported fixed_corr value")
+
+
+    def forward(self,X,y,task_mask,pred_weight,intercept_mask=None,avgIntercept=False):
+        """
+        dCSFA-NMF forward pass
+
+        Args:
+            X (torch.Tensor): Input Features
+                Shape: ``[batch_size,n_features]``
+            y (torch.Tensor): ground truth labels
+                Shape: ``[batch_size,n_sup_networks]``
+            task_mask (torch.Tensor): per window mask for whether or not predictions should be counted
+                Shape: ``[batch_size,n_sup_networks]``
+            pred_weight (torch.Tensor): per window classification importance weighting
+                Shape: ``[batch_size,1]``
+            intercept_mask (torch.Tensor, optional): window specific intercept mask. Defaults to None.
+                Shape: ``[batch_size,n_intercepts]``
+            avgIntercept (bool, optional): Whether or not to average intercepts - used in evaluation. Defaults to False.
+
+        Returns:
+            recon_loss (torch.Tensor): recon_weight*full_recon_loss + sup_recon_weight*sup_recon_loss
+            pred_loss (torch.Tensor): sup_weight*BCELoss()
+        """
+        #Get the scores from the encoder
+        s = self.get_embedding(X)
+
+        #Get the reconstruction losses
+        recon_loss = self.NMF_decoder_forward(X,s)
+
+        #Get predictions
+        y_pred = self.get_all_class_predictions(X,s,intercept_mask,avgIntercept)
+        pred_loss = self.sup_weight*self.pred_loss_f(weight=pred_weight)(y_pred*task_mask,y*task_mask)
+
+        #recon loss and pred loss are left seperate so only recon_loss can be applied for
+        #encoder pretraining
+        return recon_loss, pred_loss
+
+    @torch.no_grad()
+    def transform(self,X,intercept_mask=None,avgIntercept=True,return_npy=True):
+        """
+        Transform method to return reconstruction, predictions, and projections
+
+        Args:
+            X (torch.Tensor): Input Features
+                Shape: ``[batch_size,n_features]``
+            intercept_mask (torch.Tensor, optional): window specific intercept mask. Defaults to None.
+                Shape: ``[batch_size,n_intercepts]``
+            avgIntercept (bool, optional): Whether or not to average intercepts - used in evaluation. Defaults to False.
+            return_npy (bool, optional): Whether or not to convert to numpy arrays. Defaults to True.
+
+        Returns:
+            X_recon (torch.Tensor) : Full reconstruction of input features
+                Shape: ``[n_samples,n_features]``
+            y_pred (torch.Tensor) : All task predictions
+                Shape: ``[n_samples,n_sup_networks]``
+            s (torch.Tensor) : Network activation scores
+                Shape: ``[n_samples,n_components]``
+        """
+        if not torch.is_tensor(X):
+            X = torch.Tensor(X).float().to(self.device)
+
+        s = self.get_embedding(X)
+        X_recon = self.get_all_comp_recon(s)
+        y_pred = self.get_all_class_predictions(X,s,intercept_mask,avgIntercept)
+
+        if return_npy:
+            s = s.detach().cpu().numpy()
+            X_recon = X_recon.detach().cpu().numpy()
+            y_pred = y_pred.detach().cpu().numpy()
+        
+        return X_recon, y_pred, s
+
+
+    def pretrain_encoder(self,X,y,y_pred_weights,task_mask,intercept_mask,sample_weights,n_pre_epochs=100,batch_size=128):
+        """
+        Pretrains the encoder to find a corresponding mapping to the pretrained NMF decoder
+
+        Args:
+            X (torch.Tensor): Input Features
+                Shape: ``[n_samples,n_features]``
+            y (torch.Tensor): ground truth labels
+                Shape: ``[n_samples,n_sup_networks]``
+            task_mask (torch.Tensor): per window mask for whether or not predictions should be counted
+                Shape: ``[n_samples,n_sup_networks]``
+            y_pred_weight (torch.Tensor): per window classification importance weighting
+                Shape: ``[n_samples,1]``
+            intercept_mask (torch.Tensor, optional): window specific intercept mask. Defaults to None.
+                Shape: ``[n_samples,n_intercepts]``
+            sample_weights (torch.Tensor): Gradient Descent sampling weights.
+                Shape: ``[n_samples,1]
+            n_pre_epochs (int,optional): number of epochs for pretraining the encoder. Defaults to 100
+            batch_size (int,optional): batch size for pretraining. Defaults to 128
+        """
+        #Freeze the decoder
+        self.W_nmf.requires_grad = False
+
+        #Load arguments onto device
+        X = torch.Tensor(X).float().to(self.device)
+        y = torch.Tensor(y).float().to(self.device)
+        y_pred_weights = torch.Tensor(y_pred_weights).float().to(self.device)
+        task_mask = torch.Tensor(task_mask).long().to(self.device)
+        intercept_mask = torch.Tensor(intercept_mask).to(self.device)
+        sample_weights = torch.Tensor(sample_weights).to(self.device)
+
+        #create a dset
+        dset = TensorDataset(X,y,y_pred_weights,task_mask,intercept_mask)
+        sampler = WeightedRandomSampler(sample_weights,len(sample_weights))
+        loader = DataLoader(dset,batch_size=batch_size,sampler=sampler)
+
+        #Instantiate Optimizer
+        optimizer = self.instantiate_optimizer()
+
+        #Define iterator
+        if self.verbose:
+            epoch_iter = tqdm(range(n_pre_epochs))
+        else:
+            epoch_iter = range(n_pre_epochs)
+
+        for epoch in epoch_iter:
+            r_loss = 0.0
+            for X_batch,y_batch,y_pred_weights_batch,task_mask_batch,intercept_mask_batch in loader:
+                optimizer.zero_grad()
+                recon_loss,_ = self.forward(X_batch,y_batch,task_mask_batch,y_pred_weights_batch,intercept_mask_batch)
+                recon_loss.backward()
+                optimizer.step()
+                r_loss += recon_loss.item()
+            
+            if self.verbose:
+                epoch_iter.set_description("Encoder Pretrain Epoch: {}, Recon Loss: {:.6}".format(epoch,r_loss/len(loader)))
+
+        #Unfreeze the NMF decoder
+        self.W_nmf.requires_grad = True
+
+    def fit(self,X,y,y_pred_weights=None,task_mask=None,intercept_mask=None,y_sample_groups=None,n_epochs=100,n_pre_epochs=100,nmf_max_iter=100,
+            batch_size=128,lr=1e-3,pretrain=True,verbose=False,X_val=None,y_val=None,y_pred_weights_val=None,task_mask_val=None,
+            best_model_name="dCSFA-NMF-best-model.pt"):
+        """
+        fit the model
+
+        Args:
+            X (np.ndarray): Input Features
+                Shape: ``[n_samples, n_features]``
+            y (np.ndarray): ground truth labels
+                Shape: ``[n_samples, n_sup_networks]``
+            y_pred_weights (np.ndarray, optional): supervision window specific importance weights. Defaults to None.
+                Shape: ``[n_samples,1]``
+            task_mask (np.ndarray, optional): identifies which windows should be trained on which tasks. Defaults to None.
+                Shape: ``[n_samples,n_sup_networks]``
+            intercept_mask (np.ndarray, optional): One-Hot Mask for group specific intercepts in the logistic regression model. Defaults to None.
+                Shape: ``[n_samples,n_intercepts]``
+            y_sample_groups (_type_, optional): groups for creating sample weights - each group will be sampled evenly. Defaults to None.
+                Shape: ``[n_samples,1]``
+            n_epochs (int, optional): number of training epochs. Defaults to 100.
+            n_pre_epochs (int, optional): number of pretraining epochs. Defaults to 100.
+            nmf_max_iter (int, optional): max iterations for NMF pretraining solver. Defaults to 100.
+            batch_size (int, optional): batch size for gradient descent. Defaults to 128.
+            lr (_type_, optional): learning rate for gradient descent. Defaults to 1e-3.
+            pretrain (bool, optional): whether or not to pretrain the generative model. Defaults to True.
+            verbose (bool, optional): activate or deactivate print statements. Defaults to False.
+            X_val (np.ndarray, optional): Validation Features for checkpointing. Defaults to None.
+                Shape: ``[n_val_samples,n_features]``
+            y_val (np.ndarray, optional): Validation Labels for checkpointing. Defaults to None.
+                Shape: ``[n_val_samples,n_sup_networks]``
+            y_pred_weights_val (np.ndarray, optional): window specific classification weights. Defaults to None.
+                Shape: ``[n_val_samples,1]``
+            task_mask_val (np.ndarray, optional): validation task relevant window masking. Defaults to None.
+                Shape: ``[n_val_samples,n_sup_networks]``
+            best_model_name (str, optional): save file name for the best model. Must end in ".pt". Defaults to "dCSFA-NMF-best-model.pt".
+        """
+        #Initialize model parameters
+        self._initialize(X.shape[1])
+
+        #establish loss histories
+        self.training_hist = [] #tracks average overall loss value during training
+        self.recon_hist = [] #tracks training data mse
+        self.pred_hist = [] #tracks training data aucs
+
+        #Globaly activate/deactivate print statements
+        self.verbose=verbose
+        self.lr = lr
+
+        #Fill default values
+        if intercept_mask is None:
+            intercept_mask = np.ones((X.shape[0],self.n_intercepts))
+
+        if task_mask is None:
+            task_mask = np.ones(y.shape)
+
+        if y_pred_weights is None:
+            y_pred_weights = np.ones((y.shape[0],1))
+
+        #Fill sampler parameters
+        if y_sample_groups is None:
+            y_sample_groups = np.ones((y.shape[0]))
+            samples_weights = y_sample_groups
+        else:
+            class_sample_counts = np.array([np.sum(y_sample_groups==group) for group in np.unique(y_sample_groups)])
+            weight = 1. / class_sample_counts
+            samples_weights = np.array([weight[t] for t in y_sample_groups.astype(int)]).squeeze()
+            samples_weights = torch.Tensor(samples_weights)
+
+        #Pretrain the model
+        if pretrain:
+            self.pretrain_NMF(X,y,nmf_max_iter)
+            self.pretrain_encoder(X,y,y_pred_weights,task_mask,intercept_mask,samples_weights,n_pre_epochs,batch_size)
+            
+        #Send Training Arguments to Tensors
+        X = torch.Tensor(X).float().to(self.device)
+        y = torch.Tensor(y).float().to(self.device)
+        y_pred_weights = torch.Tensor(y_pred_weights).float().to(self.device)
+        task_mask = torch.Tensor(task_mask).long().to(self.device)
+        intercept_mask = torch.Tensor(intercept_mask).long().to(self.device)
+        samples_weights = torch.Tensor(samples_weights).to(self.device)
+
+        #If validation data is provided, set up the tensors
+        if X_val is not None and y_val is not None:
+            assert best_model_name.split('.')[-1] == "pt", f"Save file `{self.saveFolder + best_model_name}` must be of type .pt"
+            self.best_model_name = best_model_name
+            self.best_val_recon = 1e8
+            self.best_val_avg_auc = 0.0
+            self.val_recon_hist = []
+            self.val_pred_hist = []
+
+            if task_mask_val is None:
+                task_mask_val = np.ones(y_val.shape)
+
+            if y_pred_weights_val is None:
+                y_pred_weights_val = np.ones((y_val[:,0].shape[0],1))
+
+            X_val = torch.Tensor(X_val).float().to(self.device)
+            y_val = torch.Tensor(y_val).float().to(self.device)
+            task_mask_val = torch.Tensor(task_mask_val).long().to(self.device)
+            y_pred_weights_val = torch.Tensor(y_pred_weights_val).float().to(self.device)
+
+
+        #Instantiate the dataloader and optimizer
+        dset = TensorDataset(X,y,y_pred_weights,task_mask,intercept_mask)
+        sampler = WeightedRandomSampler(samples_weights,len(samples_weights))
+        loader = DataLoader(dset,batch_size=batch_size,sampler=sampler)
+        optimizer = self.instantiate_optimizer()
+
+        #Define Training Iterator
+        if self.verbose: 
+            print("Beginning Training")
+            epoch_iter = tqdm(range(n_epochs))
+        else:
+            epoch_iter = range(n_epochs)
+
+        #Training Loop
+        for epoch in epoch_iter:
+            epoch_loss = 0.0
+            recon_e_loss = 0.0
+            pred_e_loss = 0.0
+
+            for X_batch,y_batch,y_pred_weights_batch,task_mask_batch,intercept_mask_batch in loader:
+
+                self.train()
+                optimizer.zero_grad()
+                recon_loss, pred_loss = self.forward(X_batch,y_batch,task_mask_batch,y_pred_weights_batch,intercept_mask_batch)
+                loss = recon_loss + pred_loss #Weighting happens inside of the forward call
+                loss.backward()
+                optimizer.step()
+
+                epoch_loss += loss.item()
+                recon_e_loss += recon_loss.item()
+                pred_e_loss += pred_loss.item()
+
+            self.training_hist.append(epoch_loss / len(loader))
+            with torch.no_grad():
+                self.eval()
+                X_recon, y_pred, s = self.transform(X,y,intercept_mask,return_npy=False)
+                training_mse_loss = nn.MSELoss()(X_recon,X).item()
+                training_auc_list = []
+                for sup_net in range(self.n_sup_networks):
+                    auc = roc_auc_score(y.detach().cpu().numpy()[task_mask[:,sup_net].detach().cpu().numpy()==1,sup_net],
+                                        y_pred.detach().cpu().numpy()[task_mask[:,sup_net].detach().cpu().numpy()==1,sup_net])
+                    training_auc_list.append(auc)
+                
+                self.recon_hist.append(training_mse_loss)
+                self.pred_hist.append(training_auc_list)
+
+                #If Validation data is present, collect performance metrics
+                if X_val is not None and y_val is not None:
+                    X_recon_val,y_pred_val,s_val = self.transform(X_val,y_val,return_npy=False)
+                    validation_mse_loss = nn.MSELoss()(X_recon_val,X_val).item()
+                    validation_auc_list = []
+                    for sup_net in range(self.n_sup_networks):
+                        auc = roc_auc_score(y_val.detach().cpu().numpy()[task_mask_val[:,sup_net].detach().cpu().numpy()==1,sup_net],
+                                            y_pred_val.detach().cpu().numpy()[task_mask_val[:,sup_net].detach().cpu().numpy()==1,sup_net])
+                        validation_auc_list.append(auc)
+                    
+                    self.val_recon_hist.append(validation_mse_loss)
+                    self.val_pred_hist.append(validation_auc_list)
+
+                    if validation_mse_loss < self.best_val_recon and np.mean(validation_auc_list) > self.best_val_avg_auc:
+                        self.best_epoch = epoch
+                        self.best_val_recon = validation_mse_loss
+                        self.best_val_aucs = validation_auc_list
+                        torch.save(self.state_dict(),self.saveFolder + self.best_model_name)
+
+                    if self.verbose:
+                        epoch_iter.set_description("Epoch: {}, Best Epoch: {}, Best Val MSE: {:.6}, Best Val by Window ROC-AUC {}, current MSE: {:.6}, current AUC: {}".format(epoch,
+                                                                                                                                                                        self.best_epoch,
+                                                                                                                                                                        self.best_val_recon,
+                                                                                                                                                                        self.best_val_aucs,
+                                                                                                                                                                        validation_mse_loss,
+                                                                                                                                                                        validation_auc_list))
+                else:
+                    epoch_iter.set_description("Epoch: {}, Current Training MSE: {:.6}, Current Training by Window ROC-AUC: {}".format(epoch,training_mse_loss,training_auc_list))
+        
+        if self.verbose:
+            print("Saving the last epoch with training MSE: {:.6} and AUCs:{}".format(training_mse_loss,training_auc_list))
+        torch.save(self.state_dict(),self.saveFolder + "dCSFA-NMF-last-epoch.pt") #Last epoch is saved in case the saved 'best model' doesn't make sense
+        
+        if X_val is not None and y_val is not None:
+            if self.verbose:
+                print("Loaded the best model from Epoch: {} with MSE: {:.6} and AUCs: {}".format(self.best_epoch,self.best_val_recon,self.best_val_aucs))
+            self.load_state_dict(torch.load(self.saveFolder+self.best_model_name))
+
+    def load_last_epoch(self):
+        """
+        Loads model parameters of the last epoch in case the last epoch is preferable to the early stop
+        checkpoint conditions. This will be visible in the training printout if self.verbose=True
+        """
+        self.load_state_dict(torch.load(self.saveFolder + "dCSFA-NMF-last-epoch.pt"))
+
+    def reconstruct(self,X,component=None):
+        """
+        Gets full or partial reconstruction.
+
+        Args:
+            X (numpy.ndarray): Input Features
+                Shape: ``[n_samples,n_features]``
+            component (int,optional):identifies which component to use for reconstruction
+
+        Returns:
+            X_recon: Full recon if component=None, else, recon for network[comopnent]
+        """
+        X_recon,_,s = self.transform(X)
+
+        if component is not None:
+            X_recon = self.get_comp_recon(s,component)
+
+        return X_recon
+
+    def predict_proba(self,X,return_scores=False):
+        """
+        Returns prediction probabilities
+        Args:
+            X (numpy.ndarray): Input Features
+                Shape: ``[n_samples,n_features]``
+            return_scores (bool, optional): Whether or not to include the projections. Defaults to False.
+
+        Returns:
+            y_pred_proba (numpy.ndarray): predictions
+                Shape: ``[n_samples,n_sup_networks]``
+            s (numpy.ndarray): supervised network activation scores
+                Shape: ``[n_samples,n_components]
+        """
+        _,y_pred,s = self.transform(X)
+
+        if return_scores:
+            return y_pred, s
+        else:
+            return y_pred
+
+    def predict(self,X,return_scores=False):
+        """
+        Returns binned predictions
+        Args:
+            X (numpy.ndarray): Input Features
+            return_scores (bool, optional): Whether or not to include the projections. Defaults to False.
+
+        Returns:
+            y_pred_proba (numpy.ndarray): predictions in {0,1}
+                Shape: ``[n_samples,n_sup_networks]``
+            s (numpy.ndarray): supervised network activation scores
+                Shape: ``[n_samples,n_components]
+        """
+        _,y_pred,s = self.transform(X)
+
+        if return_scores:
+            return y_pred > 0.5, s
+        else:
+            return y_pred > 0.5
+
+    def project(self,X):
+        """
+        Get projections
+
+        Args:
+            X (numpy.ndarray): Input Features
+                Shape: ``[n_samples,n_features]
+            return_scores (bool, optional): Whether or not to include the projections. Defaults to False.
+
+        Returns:
+            s (numpy.ndarray): supervised network activation scores
+                Shape: ``[n_samples,n_components]
+        """
+        _,_,s = self.transform(X)
+        return s
+
+    def score(self,X,y,groups=None,return_dict=False):
+        """
+        Gets a list of task AUCs either by group or for all samples. Can return
+        a dictionary with AUCs for each group with each group label as a key.
+
+        Args:
+            X (numpy.ndarray): Input Features
+                Shape: ``[n_samples,n_features]
+            y (numpy.ndarray): Ground Truth Labels
+                Shape: ``[n_samples,n_sup_networks]``
+
+            groups (numpy.ndarray, optional): per window group assignment labels. Defaults to None.
+                Shape: ``[n_samples,1]``
+            return_dict (bool, optional): Whether or not to return a dictionary with values for each group. Defaults to False.
+
+        Returns:
+            score_results: Array or Dictionary of results either as the mean performance of all groups, the performance of all samples, 
+                or a dictionary of results for each group.
+        """
+        _,y_pred,_ = self.transform(X)
+
+        if groups is not None:
+            auc_dict = {}
+            for group in np.unique(groups):
+                auc_list = []
+                for sup_net in range(self.n_sup_networks):
+                    auc = roc_auc_score(y[:,sup_net],y_pred[:,sup_net])
+                    auc_list.append(auc)
+                
+                auc_dict[group] = auc_list
+
+            if return_dict:
+                score_results = auc_dict
+
+            else:
+                auc_array = np.vstack([auc_dict[key] for key in np.unique(groups)])
+                score_results = np.mean(auc_array,axis=0)
+        
+        else:
+            auc_list = []
+            for sup_net in range(self.n_sup_networks):
+                auc = roc_auc_score(y[:,sup_net],y_pred[:,sup_net])
+                auc_list.append(auc)
+
+            score_results = np.array(auc_list)
+
+        return score_results
+
+
+
+
+
+            
+
+
+
+
+
+
+
+        

--- a/lpne/models/grid_search_cv.py
+++ b/lpne/models/grid_search_cv.py
@@ -12,8 +12,7 @@ from sklearn.utils.validation import check_is_fitted
 import torch
 
 
-FIT_ATTRIBUTES = ['best_estimator_', 'best_params_', 'best_score_']
-
+FIT_ATTRIBUTES = ["best_estimator_", "best_params_", "best_score_"]
 
 
 class GridSearchCV:
@@ -39,13 +38,12 @@ class GridSearchCV:
         self.cv = cv
         self.test_size = test_size
 
-
     def fit(self, features, labels, groups, print_freq=5, score_freq=5):
         """
         Fit the model to data.
 
         These parameters are passed to ``BaseModel.fit``.
-        
+
         If ``groups`` is ``None``, a label-stratified K-fold is use for model
         selection. Otherwise, a group shuffle used.
 
@@ -72,7 +70,7 @@ class GridSearchCV:
             # Make sure groups aren't in multiple folds.
             skf = GroupShuffleSplit(test_size=self.test_size, n_splits=self.cv)
             cv_gen = enumerate(skf.split(features, labels, groups))
-        
+
         best_score = -np.inf
         best_params = None
         # For each parameter setting...
@@ -86,16 +84,16 @@ class GridSearchCV:
                 # Set the parameters, fit the model, and score the model.
                 self.model.set_params(**params)
                 self.model.fit(
-                        features[train_idx],
-                        labels[train_idx],
-                        groups[train_idx],
-                        print_freq=print_freq,
-                        score_freq=score_freq,
+                    features[train_idx],
+                    labels[train_idx],
+                    groups[train_idx],
+                    print_freq=print_freq,
+                    score_freq=score_freq,
                 )
                 model_score = self.model.score(
-                        features[test_idx],
-                        labels[test_idx],
-                        groups[test_idx],
+                    features[test_idx],
+                    labels[test_idx],
+                    groups[test_idx],
                 )
                 print(
                     f"Param {param_num} cv {cv_num} score {model_score}",
@@ -110,16 +108,15 @@ class GridSearchCV:
         # Retrain using the best found parameters.
         self.model.set_params(**best_params)
         self.model.fit(
-                features,
-                labels,
-                groups,
-                print_freq=print_freq,
-                score_freq=score_freq,
+            features,
+            labels,
+            groups,
+            print_freq=print_freq,
+            score_freq=score_freq,
         )
         self.best_estimator_ = self.model
         self.best_params_ = best_params
         self.best_score_ = best_score
-
 
     def predict(self, features, groups, *args, **kwargs):
         """
@@ -139,7 +136,6 @@ class GridSearchCV:
         """
         check_is_fitted(self, attributes=FIT_ATTRIBUTES)
         return self.best_estimator_.predict(features, groups, *args, **kwargs)
-
 
     def score(self, features, labels, groups, *args, **kwargs):
         """
@@ -161,13 +157,12 @@ class GridSearchCV:
         """
         check_is_fitted(self, attributes=FIT_ATTRIBUTES)
         return self.best_estimator_.score(
-                features,
-                labels,
-                groups,
-                *args,
-                **kwargs,
+            features,
+            labels,
+            groups,
+            *args,
+            **kwargs,
         )
-
 
     @torch.no_grad()
     def save_state(self, fn):
@@ -177,10 +172,8 @@ class GridSearchCV:
         np.save(fn, params)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/models/nmf_base.py
+++ b/lpne/models/nmf_base.py
@@ -8,6 +8,7 @@ import torch.nn as nn
 from tqdm import tqdm
 import numpy as np
 from sklearn.decomposition import NMF
+
 try:
     from torchbd.loss import BetaDivLoss
 

--- a/lpne/models/nmf_base.py
+++ b/lpne/models/nmf_base.py
@@ -8,7 +8,12 @@ import torch.nn as nn
 from tqdm import tqdm
 import numpy as np
 from sklearn.decomposition import NMF
-from torchbd.loss import BetaDivLoss
+try:
+    from torchbd.loss import BetaDivLoss
+
+    TORCHBD_INSTALLED = True
+except ModuleNotFoundError:
+    TORCHBD_INSTALLED = False
 from scipy.stats import mannwhitneyu
 
 
@@ -107,7 +112,7 @@ class NmfBase(nn.Module):
         self.feature_groups = feature_groups
         if feature_groups is not None and group_weights is None:
             group_weights = []
-            for idx, (lb, ub) in enumerate(feature_groups):
+            for (lb, ub) in feature_groups:
                 group_weights.append(
                     (feature_groups[-1][-1] - feature_groups[0][0]) / (ub - lb)
                 )
@@ -162,6 +167,7 @@ class NmfBase(nn.Module):
         if recon_loss == "MSE":
             return nn.MSELoss()
         elif recon_loss == "IS":
+            assert TORCHBD_INSTALLED, "torchbd needs to be installed!"
             return BetaDivLoss(beta=0, reduction="mean")
         else:
             raise ValueError(f"{recon_loss} is not supported")

--- a/lpne/models/nmf_base_model.py
+++ b/lpne/models/nmf_base_model.py
@@ -9,11 +9,35 @@ from scipy.stats import mannwhitneyu
 
 
 class NMF_Base(nn.Module):
-
     def __init__(self,n_components,device='auto',n_sup_networks=1,fixed_corr=None,recon_loss="MSE",recon_weight=1.0,sup_recon_type="Residual",
                 sup_recon_weight=1.0,sup_smoothness_weight=1,feature_groups=None,group_weights=None,verbose=False):
-        super(NMF_Base,self).__init__()
+        """
+        Base model for dCSFA-NMF decoder based methods
 
+        Args:
+            n_components (int): number of networks to learn or latent dimensionality
+            device (str, optional): torch device in {"cuda","cpu","auto"}. Defaults to 'auto'.
+            n_sup_networks (int, optional): Number of networks that will be supervised (0 < n_sup_networks < n_components). Defaults to 1.
+            fixed_corr (list of str, optional): List the same length as n_sup_networks indicating correlation constraints for the network. Defaults to None.
+                "positive" - constrains a supervised network to have a positive correlation between score and label
+                "negative" - constrains a supervised network to have a negative correlation between score and label
+                "n/a" - no constraint is applied and the supervised network can be positive or negatively correlated. 
+            recon_loss (str, optional): Reconstruction loss function in {"IS","MSE"}. Defaults to 'MSE'.
+            recon_weight (float, optional): Importance weight for the reconstruction. Defaults to 1.0.
+            sup_recon_type (str, optional): Which supervised component reconstruction loss to use in {"Residual","All"}. Defaults to "Residual".
+                "Residual" - Estimates network scores optimal for reconstruction and penalizes deviation of the real scores from those values
+                "All" - Evaluates the recon_loss of the supervised network reconstruction against all features. 
+            sup_recon_weight (float, optional): Importance weight for the reconstruction of the supervised component. Defaults to 1.0.
+            sup_smoothness_weight (float, optional): Encourages smoothness for the supervised network. Defaults to 1.0.
+            feature_groups (list of int, optional): Indices of the divisions of feature types. Defaults to None.
+            group_weights (list of floats, optional): Weights for each of the feature types. Defaults to None.
+            verbose (bool, optional): Activates or deactivates print statements globally. Defaults to False.
+
+        Raises:
+            ValueError: raises error if fixed corr values are not in {"positive","negative","n/a"}
+        """
+        super(NMF_Base,self).__init__()
+        
         self.n_components = n_components
         self.n_sup_networks = n_sup_networks
         self.recon_loss = recon_loss

--- a/lpne/models/nmf_base_model.py
+++ b/lpne/models/nmf_base_model.py
@@ -1,6 +1,10 @@
+"""
+NMF base class
+
+"""
+__date__ = "September - October 2022"
 import torch
 import torch.nn as nn
-from torch.utils.data import TensorDataset, DataLoader
 from tqdm import tqdm
 import numpy as np
 from sklearn.decomposition import NMF
@@ -8,36 +12,72 @@ from torchbd.loss import BetaDivLoss
 from scipy.stats import mannwhitneyu
 
 
-class NMF_Base(nn.Module):
-    def __init__(self,n_components,device='auto',n_sup_networks=1,fixed_corr=None,recon_loss="MSE",recon_weight=1.0,sup_recon_type="Residual",
-                sup_recon_weight=1.0,sup_smoothness_weight=1,feature_groups=None,group_weights=None,verbose=False):
-        """
-        Base model for dCSFA-NMF decoder based methods
+class NmfBase(nn.Module):
+    """
+    Base class for DcsfaNmf models
 
-        Args:
-            n_components (int): number of networks to learn or latent dimensionality
-            device (str, optional): torch device in {"cuda","cpu","auto"}. Defaults to 'auto'.
-            n_sup_networks (int, optional): Number of networks that will be supervised (0 < n_sup_networks < n_components). Defaults to 1.
-            fixed_corr (list of str, optional): List the same length as n_sup_networks indicating correlation constraints for the network. Defaults to None.
-                "positive" - constrains a supervised network to have a positive correlation between score and label
-                "negative" - constrains a supervised network to have a negative correlation between score and label
-                "n/a" - no constraint is applied and the supervised network can be positive or negatively correlated. 
-            recon_loss (str, optional): Reconstruction loss function in {"IS","MSE"}. Defaults to 'MSE'.
-            recon_weight (float, optional): Importance weight for the reconstruction. Defaults to 1.0.
-            sup_recon_type (str, optional): Which supervised component reconstruction loss to use in {"Residual","All"}. Defaults to "Residual".
-                "Residual" - Estimates network scores optimal for reconstruction and penalizes deviation of the real scores from those values
-                "All" - Evaluates the recon_loss of the supervised network reconstruction against all features. 
-            sup_recon_weight (float, optional): Importance weight for the reconstruction of the supervised component. Defaults to 1.0.
-            sup_smoothness_weight (float, optional): Encourages smoothness for the supervised network. Defaults to 1.0.
-            feature_groups (list of int, optional): Indices of the divisions of feature types. Defaults to None.
-            group_weights (list of floats, optional): Weights for each of the feature types. Defaults to None.
-            verbose (bool, optional): Activates or deactivates print statements globally. Defaults to False.
+    Raises
+    ------
+    * ``ValueError``: if fixed corr values are not in {"positive","negative","n/a"}
 
-        Raises:
-            ValueError: raises error if fixed corr values are not in {"positive","negative","n/a"}
-        """
-        super(NMF_Base,self).__init__()
-        
+    Parameters
+    ----------
+    n_components : int
+        number of networks to learn or latent dimensionality
+    device : str, optional
+        torch device in {"cuda","cpu","auto"}. Defaults to 'auto'.
+    n_sup_networks : int, optional
+        Number of networks that will be supervised
+        ``(0 < n_sup_networks < n_components)``. Defaults to ``1``.
+    fixed_corr : list of str, optional
+        List the same length as n_sup_networks indicating correlation constraints
+        for the network. Defaults to None.
+        "positive" - constrains a supervised network to have a positive correlation
+        between score and label
+        "negative" - constrains a supervised network to have a negative correlation
+        between score and label
+        "n/a" - no constraint is applied and the supervised network can be positive
+        or negatively correlated.
+    recon_loss : str, optional
+        Reconstruction loss function in ``{"IS","MSE"}``. Defaults to ``'MSE'``.
+    recon_weight : float, optional
+        Importance weight for the reconstruction. Defaults to 1.0.
+    sup_recon_type : str, optional
+        Which supervised component reconstruction loss to use in {"Residual","All"}.
+        Defaults to ``"Residual"``.
+        "Residual" - Estimates network scores optimal for reconstruction and
+        penalizes deviation of the real scores from those values
+        "All" - Evaluates the recon_loss of the supervised network reconstruction
+        against all features.
+    sup_recon_weight : float, optional
+        Importance weight for the reconstruction of the supervised component.
+        Defaults to ``1.0``.
+    sup_smoothness_weight : float, optional
+        Encourages smoothness for the supervised network. Defaults to ``1.0``.
+    feature_groups : list of int, optional
+        Indices of the divisions of feature types. Defaults to None.
+    group_weights : list of floats, optional
+        Weights for each of the feature types. Defaults to None.
+    verbose : bool, optional
+        Activates or deactivates print statements globally. Defaults to False.
+    """
+
+    def __init__(
+        self,
+        n_components,
+        device="auto",
+        n_sup_networks=1,
+        fixed_corr=None,
+        recon_loss="MSE",
+        recon_weight=1.0,
+        sup_recon_type="Residual",
+        sup_recon_weight=1.0,
+        sup_smoothness_weight=1,
+        feature_groups=None,
+        group_weights=None,
+        verbose=False,
+    ):
+        super(NmfBase, self).__init__()
         self.n_components = n_components
         self.n_sup_networks = n_sup_networks
         self.recon_loss = recon_loss
@@ -46,13 +86,11 @@ class NMF_Base(nn.Module):
         self.sup_smoothness_weight = sup_smoothness_weight
         self.sup_recon_weight = sup_recon_weight
         self.verbose = verbose
-
         self.recon_loss_f = self.get_recon_loss(recon_loss)
-
-        #Set correlation constraints
+        # Set correlation constraints
         if fixed_corr == None:
             self.fixed_corr = ["n/a" for sup_net in range(self.n_sup_networks)]
-        elif type(fixed_corr)!=list:
+        elif type(fixed_corr) != list:
             if fixed_corr.lower() == "positive":
                 self.fixed_corr = ["positive"]
             elif fixed_corr.lower() == "negative":
@@ -60,45 +98,48 @@ class NMF_Base(nn.Module):
             elif fixed_corr.lower() == "n/a":
                 self.fixed_corr = ["n/a"]
             else:
-                raise ValueError("fixed corr must be a list or in {`positive`,`negative`,`n/a`}")
+                raise ValueError(
+                    "fixed corr must be a list or in {`positive`,`negative`,`n/a`}"
+                )
         else:
             assert len(fixed_corr) == len(range(self.n_sup_networks))
             self.fixed_corr = fixed_corr
-
         self.feature_groups = feature_groups
         if feature_groups is not None and group_weights is None:
             group_weights = []
-            for idx,(lb,ub) in enumerate(feature_groups):
-                group_weights.append((feature_groups[-1][-1] - feature_groups[0][0])/(ub - lb))
+            for idx, (lb, ub) in enumerate(feature_groups):
+                group_weights.append(
+                    (feature_groups[-1][-1] - feature_groups[0][0]) / (ub - lb)
+                )
             self.group_weights = group_weights
         else:
             self.group_weights = group_weights
 
-        if device == 'auto':
-            self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        if device == "auto":
+            self.device = "cuda" if torch.cuda.is_available() else "cpu"
         else:
             self.device = device
 
-    def _initialize_NMF(self,dim_in):
+    def _initialize_NMF(self, dim_in):
         """
-        Instantiates the NMF decoder and moves the NMF_Base instance to self.device
+        Instantiates the NMF decoder and moves the NmfBase instance to self.device
 
         Parameters
         ----------
         dim_in : int
             Number of total features
         """
-        self.W_nmf = nn.Parameter(torch.rand(self.n_components,dim_in))
+        self.W_nmf = nn.Parameter(torch.rand(self.n_components, dim_in))
         self.to(self.device)
 
     @staticmethod
     def inverse_softplus(x, eps=1e-5):
-        '''
+        """
         Gets the inverse softplus for sklearn model pretraining
-        '''
+        """
         # Calculate inverse softplus
-        x_inv_softplus = np.log(np.exp(x+eps) - (1.0 - eps))
-        
+        x_inv_softplus = np.log(np.exp(x + eps) - (1.0 - eps))
+
         # Return inverse softplus
         return x_inv_softplus
 
@@ -109,7 +150,7 @@ class NMF_Base(nn.Module):
         return nn.Softplus()(self.W_nmf)
 
     @torch.no_grad()
-    def get_recon_loss(self,recon_loss):
+    def get_recon_loss(self, recon_loss):
         """
         Returns the reconstruction loss function
 
@@ -121,15 +162,15 @@ class NMF_Base(nn.Module):
         if recon_loss == "MSE":
             return nn.MSELoss()
         elif recon_loss == "IS":
-            return BetaDivLoss(beta=0,reduction="mean")
+            return BetaDivLoss(beta=0, reduction="mean")
         else:
             raise ValueError(f"{recon_loss} is not supported")
 
     @torch.no_grad()
-    def get_optim(self,optim_name):
-        '''
+    def get_optim(self, optim_name):
+        """
         returns a torch optimizer based on text input from the user
-        '''
+        """
         if optim_name == "AdamW":
             return torch.optim.AdamW
         elif optim_name == "Adam":
@@ -140,119 +181,122 @@ class NMF_Base(nn.Module):
             raise ValueError(f"{optim_name} is not supported")
 
     @torch.no_grad()
-    def pretrain_NMF(self,X,y,nmf_max_iter=100):
+    def pretrain_NMF(self, X, y, nmf_max_iter=100):
         """
-        Trains an unsupervised NMF model and sorts components by predictiveness for corresponding tasks.
-        Saved NMF components are stored as a member variable self.W_nmf. Sklearn NMF model is saved as
-        NMF_init.
+        Trains an unsupervised NMF model and sorts components by predictiveness for
+        corresponding tasks.
+        Saved NMF components are stored as a member variable self.W_nmf. Sklearn NMF
+        model is saved as NMF_init.
 
         Parameters
         ----------
         X : numpy.ndarray
             Input features
             Shape: ``[n_samps,n_features]``
-        
         y : numpy.ndarray
             Input labels
             Shape: ``[n_samps,n_sup_networks]``
-
         nmf_max_iter : int
             Maximum iterations for convergence using sklearn.decomposition.NMF
-        
-        Returns
-        ---------
-
-        None
         """
-
-        if self.verbose: print("Pretraining NMF...")
-
+        if self.verbose:
+            print("Pretraining NMF...")
         # Initialize the model - solver corresponds to defined recon loss
         if self.recon_loss == "IS":
-            self.NMF_init = NMF(n_components=self.n_components,solver="mu",beta_loss="itakura-saito",init='nndsvda',max_iter=nmf_max_iter)
+            self.NMF_init = NMF(
+                n_components=self.n_components,
+                solver="mu",
+                beta_loss="itakura-saito",
+                init="nndsvda",
+                max_iter=nmf_max_iter,
+            )
         else:
-            self.NMF_init = NMF(n_components=self.n_components,max_iter=nmf_max_iter,init="nndsvd")
-
-        #Fit the model
+            self.NMF_init = NMF(
+                n_components=self.n_components, max_iter=nmf_max_iter, init="nndsvd"
+            )
+        # Fit the model
         s_NMF = self.NMF_init.fit_transform(X)
-
-        #define arrays for storing model predictive information
+        # define arrays for storing model predictive information
         selected_networks = []
         selected_aucs = []
         final_network_order = []
-
-        #Find the most predictive component for each task - the first task gets priority
+        # Find the most predictive component for each task - the first task gets priority
         for sup_net in range(self.n_sup_networks):
-            
-            #Prep labels and set auc storage
+            # Prep labels and set auc storage
             class_auc_list = []
-
-            #Create progress bar if verbose
+            # Create progress bar if verbose
             if self.verbose:
-                print("Identifying predictive components for supervised network {}".format(sup_net))
+                print(
+                    "Identifying predictive components for supervised network {}".format(
+                        sup_net
+                    )
+                )
                 component_iter = tqdm(range(self.n_components))
             else:
                 component_iter = range(self.n_components)
-
-            #Find each components AUC for the current task
+            # Find each components AUC for the current task
             for component in component_iter:
-                s_pos = s_NMF[y[:,sup_net]==1,component].reshape(-1,1)
-                s_neg = s_NMF[y[:,sup_net]==0,component].reshape(-1,1)
-                U,_ = mannwhitneyu(s_pos,s_neg)
+                s_pos = s_NMF[y[:, sup_net] == 1, component].reshape(-1, 1)
+                s_neg = s_NMF[y[:, sup_net] == 0, component].reshape(-1, 1)
+                U, _ = mannwhitneyu(s_pos, s_neg)
                 U = U.squeeze()
-                auc = U/(len(s_pos)*len(s_neg))
-
+                auc = U / (len(s_pos) * len(s_neg))
                 class_auc_list.append(auc)
-
-            class_auc_list = np.array(class_auc_list) 
-
-            #Sort AUC predictions based on correlations
+            class_auc_list = np.array(class_auc_list)
+            # Sort AUC predictions based on correlations
             predictive_order = np.argsort(np.abs(class_auc_list - 0.5))[::-1]
             positive_predictive_order = np.argsort(class_auc_list)[::-1]
-            negative_predictive_order = np.argsort(1-class_auc_list)[::-1]
-
-            #Ignore components that have been used for previous supervised tasks
+            negative_predictive_order = np.argsort(1 - class_auc_list)[::-1]
+            # Ignore components that have been used for previous supervised tasks
             if len(selected_networks) > 0:
                 for taken_network in selected_networks:
-                    predictive_order = predictive_order[predictive_order != taken_network]
-                    positive_predictive_order = positive_predictive_order[positive_predictive_order != taken_network]
-                    negative_predictive_order = negative_predictive_order[negative_predictive_order != taken_network]
-
-            #Select the component based on predictive correlation
-            if self.fixed_corr[sup_net]=="n/a":
+                    predictive_order = predictive_order[
+                        predictive_order != taken_network
+                    ]
+                    positive_predictive_order = positive_predictive_order[
+                        positive_predictive_order != taken_network
+                    ]
+                    negative_predictive_order = negative_predictive_order[
+                        negative_predictive_order != taken_network
+                    ]
+            # Select the component based on predictive correlation
+            if self.fixed_corr[sup_net] == "n/a":
                 current_net = predictive_order[0]
-                
-            elif self.fixed_corr[sup_net].lower()=="positive":
+            elif self.fixed_corr[sup_net].lower() == "positive":
                 current_net = positive_predictive_order[0]
-
-            elif self.fixed_corr[sup_net].lower()=="negative":
+            elif self.fixed_corr[sup_net].lower() == "negative":
                 current_net = negative_predictive_order[0]
-
             current_auc = class_auc_list[current_net.astype(int)]
-
-            #Declare the selected network and save the network and chosen AUCs
+            # Declare the selected network and save the network and chosen AUCs
             if self.verbose:
-                print("Selecting network: {} with auc {} for sup net {} using constraint {} correlation".format(current_net,current_auc,sup_net,self.fixed_corr[sup_net]))
+                print(
+                    "Selecting network: {} with auc {} for sup net {} using constraint {} correlation".format(
+                        current_net, current_auc, sup_net, self.fixed_corr[sup_net]
+                    )
+                )
             selected_networks.append(current_net)
             selected_aucs.append(selected_aucs)
             predictive_order = predictive_order[predictive_order != current_net]
-            positive_predictive_order = positive_predictive_order[positive_predictive_order != current_net]
-            negative_predictive_order = negative_predictive_order[negative_predictive_order != current_net]
-        
-        #Save the selected networks and corresponding AUCs
+            positive_predictive_order = positive_predictive_order[
+                positive_predictive_order != current_net
+            ]
+            negative_predictive_order = negative_predictive_order[
+                negative_predictive_order != current_net
+            ]
+        # Save the selected networks and corresponding AUCs
         self.skl_pretrain_networks_ = selected_networks
         self.skl_pretrain_aucs_ = selected_aucs
         final_network_order = selected_networks
-
-        #Get the final sorting of the networks for predictiveness
-        for idx,_ in enumerate(predictive_order):
+        # Get the final sorting of the networks for predictiveness
+        for idx, _ in enumerate(predictive_order):
             final_network_order.append(predictive_order[idx])
-
-        #Save the final sorted components to the W_nmf parameter
+        # Save the final sorted components to the W_nmf parameter
         sorted_NMF = self.NMF_init.components_[final_network_order]
-        self.W_nmf.data = torch.from_numpy(self.inverse_softplus(sorted_NMF.astype(np.float32))).to(self.device)
+        self.W_nmf.data = torch.from_numpy(
+            self.inverse_softplus(sorted_NMF.astype(np.float32))
+        ).to(self.device)
 
-    def get_sup_recon(self,s):
+    def get_sup_recon(self, s):
         """
         Returns the reconstruction of all of the supervised networks
 
@@ -268,13 +312,15 @@ class NMF_Base(nn.Module):
             Reconstruction using only supervised components
             Shape: ``[n_samps,n_features]``
         """
-        X_sup_recon = s[:,:self.n_sup_networks].view(-1,self.n_sup_networks) @ self.get_W_nmf()[:self.n_sup_networks,:].view(self.n_sup_networks,-1)
+        X_sup_recon = s[:, : self.n_sup_networks].view(
+            -1, self.n_sup_networks
+        ) @ self.get_W_nmf()[: self.n_sup_networks, :].view(self.n_sup_networks, -1)
         return X_sup_recon
 
-    def get_residual_scores(self,X,s):
+    def get_residual_scores(self, X, s):
         """
-        Returns the supervised score values that would maximize reconstruction performance based
-        on the residual reconstruction.
+        Returns the supervised score values that would maximize reconstruction
+        performance based on the residual reconstruction.
 
         s_h = (X - s_unsup @ W_unsup) @ w_sup.T @ (w_sup @ w_sup.T)^(-1)
 
@@ -283,20 +329,26 @@ class NMF_Base(nn.Module):
         X : torch.Tensor
             Ground truth features
             Shape: ``[n_samples,n_features]``
-        
         s : torch.Tensor
             Factor activation scores
             Shape: ``[n_samples,n_components]``
+
+        Returns
+        -------
+        NOTE: HERE
         """
-        resid = (X-s[:,self.n_sup_networks:] @ self.get_W_nmf()[self.n_sup_networks:,:])
-        w_sup = self.get_W_nmf()[:self.n_sup_networks,:].view(self.n_sup_networks,-1)
-        s_h = resid @ w_sup.T @ torch.inverse(w_sup@w_sup.T)
+        resid = (
+            X - s[:, self.n_sup_networks :] @ self.get_W_nmf()[self.n_sup_networks :, :]
+        )
+        w_sup = self.get_W_nmf()[: self.n_sup_networks, :].view(self.n_sup_networks, -1)
+        s_h = resid @ w_sup.T @ torch.inverse(w_sup @ w_sup.T)
         return s_h
 
-    def residual_loss_f(self,s,s_h):
+    def residual_loss_f(self, s, s_h):
         """
         Loss function between supervised factor scores and the maximal values for
-        reconstruction. Factors scores are encouraged to be non-zero by the smoothness weight.
+        reconstruction. Factors scores are encouraged to be non-zero by the smoothness
+        weight.
 
         f(s,s_h) = ||s_sup - s_h||^2 / (1 - smoothness_weight * exp(-||s_h||^2))
 
@@ -305,33 +357,35 @@ class NMF_Base(nn.Module):
         s : torch.Tensor
             Factor activation scores
             Shape: ``[n_samples,n_components]``
-
         s_h : torch.Tensor
             Factor scores that would minimize the reconstruction loss
             Shape: ``[n_samples,n_components]``
-        
+
         Returns
         ---------
         res_loss : torch.Tensor
             Residual scores loss
         """
-        res_loss = torch.norm(s[:,:self.n_sup_networks].view(-1,self.n_sup_networks)-s_h) / (1 - self.sup_smoothness_weight*torch.exp(-torch.norm(s_h)))
+        res_loss = torch.norm(
+            s[:, : self.n_sup_networks].view(-1, self.n_sup_networks) - s_h
+        ) / (1 - self.sup_smoothness_weight * torch.exp(-torch.norm(s_h)))
         return res_loss
 
-    def get_weighted_recon_loss_f(self,X_pred,X_true):
+    def get_weighted_recon_loss_f(self, X_pred, X_true):
         """
-        Model training often involves multiple feature types such as Power and Directed Spectrum that
-        have vastly different feature counts (power: n_roi*n_freq, ds: n_roi*(n_roi-1)*n_freq).
+        Model training often involves multiple feature types such as Power and Directed
+        Spectrum that have vastly different feature counts
+        ``(power: n_roi*n_freq, ds: n_roi*(n_roi-1)*n_freq)``.
 
-        This loss reweights the reconstruction of each feature group proportionally to the number of features
-        such that each feature type has roughly equal importance to the reconstruction.
+        This loss reweights the reconstruction of each feature group proportionally to
+        the number of features such that each feature type has roughly equal importance
+        to the reconstruction.
 
         Parameters
         ----------
         X_pred : torch.Tensor
             Reconstructed features
             Shape: ``[n_samps,n_features]``
-
         X_true : torch.Tensor
             Ground Truth Features
             Shape: ``[n_samps,n_features]``
@@ -342,12 +396,12 @@ class NMF_Base(nn.Module):
             Weighted reconstruction loss for each feature
         """
         recon_loss = 0.0
-        for weight,(lb,ub) in zip(self.group_weights,self.feature_groups):
-            recon_loss += weight * self.recon_loss_f(X_pred[:,lb:ub],X_true[:,lb:ub])
+        for weight, (lb, ub) in zip(self.group_weights, self.feature_groups):
+            recon_loss += weight * self.recon_loss_f(X_pred[:, lb:ub], X_true[:, lb:ub])
 
         return recon_loss
 
-    def eval_recon_loss(self,X_pred,X_true):
+    def eval_recon_loss(self, X_pred, X_true):
         """
         If using feature groups, returns weighted recon loss
         Else, returns unweighted recon loss
@@ -357,7 +411,6 @@ class NMF_Base(nn.Module):
         X_pred : torch.Tensor
             Reconstructed features
             Shape: ``[n_samps,n_features]``
-
         X_true : torch.Tensor
             Ground Truth Features
             Shape: ``[n_samps,n_features]``
@@ -368,13 +421,13 @@ class NMF_Base(nn.Module):
             Weighted or Unweighted recon loss
         """
         if self.feature_groups is None:
-            recon_loss = self.recon_loss_f(X_pred,X_true)
+            recon_loss = self.recon_loss_f(X_pred, X_true)
         else:
-            recon_loss = self.get_weighted_recon_loss_f(X_pred,X_true)
+            recon_loss = self.get_weighted_recon_loss_f(X_pred, X_true)
 
         return recon_loss
 
-    def NMF_decoder_forward(self,X,s):
+    def NMF_decoder_forward(self, X, s):
         """
         NMF Decoder forward pass
 
@@ -383,7 +436,6 @@ class NMF_Base(nn.Module):
         X : torch.Tensor
             Input Features
             Shape: ``[n_samps,n_features]``
-
         s : torch.Tensor
             Encoder embeddings / factor score activations
             Shape: ``[n_samps,n_components]``
@@ -397,21 +449,21 @@ class NMF_Base(nn.Module):
 
         X_recon = s @ self.get_W_nmf()
 
-        recon_loss += self.recon_weight*self.eval_recon_loss(X_recon,X)
+        recon_loss += self.recon_weight * self.eval_recon_loss(X_recon, X)
 
         if self.sup_recon_type == "Residual":
-            s_h = self.get_residual_scores(X,s)
-            sup_recon_loss = self.residual_loss_f(s,s_h)
+            s_h = self.get_residual_scores(X, s)
+            sup_recon_loss = self.residual_loss_f(s, s_h)
         elif self.sup_recon_type == "All":
             X_recon = self.get_sup_recon(s)
-            sup_recon_loss = self.recon_loss_f(X_recon,X)
+            sup_recon_loss = self.recon_loss_f(X_recon, X)
 
-        recon_loss += self.sup_recon_weight*sup_recon_loss
+        recon_loss += self.sup_recon_weight * sup_recon_loss
 
         return recon_loss
 
     @torch.no_grad()
-    def get_comp_recon(self,s,component):
+    def get_comp_recon(self, s, component):
         """
         Gets the reconstruction for a specific component
 
@@ -420,7 +472,6 @@ class NMF_Base(nn.Module):
         s : torch.Tensor
             Encoder embeddings / factor score activations
             Shape: ``[n_samps,n_components]``
-
         component : int, 0 <= component < n_components
             Component to use for the reconstruction
 
@@ -429,11 +480,13 @@ class NMF_Base(nn.Module):
         X_recon : numpy.ndarray
             Reconstruction using a specific component
         """
-        X_recon = s[:,component].view(-1,1) @ self.get_W_nmf()[component,:].view(1,-1)
+        X_recon = s[:, component].view(-1, 1) @ self.get_W_nmf()[component, :].view(
+            1, -1
+        )
         return X_recon.detach().cpu().numpy()
 
     @torch.no_grad()
-    def get_all_comp_recon(self,s):
+    def get_all_comp_recon(self, s):
         """
         Gets the reconstruction for all components
 
@@ -450,8 +503,9 @@ class NMF_Base(nn.Module):
         """
         X_recon = s @ self.get_W_nmf()
         return X_recon
+
     @torch.no_grad()
-    def get_factor(self,component):
+    def get_factor(self, component):
         """
         Returns the numpy array for the corresponding factor
 
@@ -465,4 +519,11 @@ class NMF_Base(nn.Module):
         factor : np.ndarray
             Factor from W_nmf
         """
-        return self.get_W_nmf()[component,:].detach().cpu().numpy()
+        return self.get_W_nmf()[component, :].detach().cpu().numpy()
+
+
+if __name__ == "__main__":
+    pass
+
+
+###

--- a/lpne/models/nmf_base_model.py
+++ b/lpne/models/nmf_base_model.py
@@ -1,0 +1,444 @@
+import torch
+import torch.nn as nn
+from torch.utils.data import TensorDataset, DataLoader
+from tqdm import tqdm
+import numpy as np
+from sklearn.decomposition import NMF
+from torchbd.loss import BetaDivLoss
+from scipy.stats import mannwhitneyu
+
+
+class NMF_Base(nn.Module):
+
+    def __init__(self,n_components,device='auto',n_sup_networks=1,fixed_corr=None,recon_loss="MSE",recon_weight=1.0,sup_recon_type="Residual",
+                sup_recon_weight=1.0,sup_smoothness_weight=1,feature_groups=None,group_weights=None,verbose=False):
+        super(NMF_Base,self).__init__()
+
+        self.n_components = n_components
+        self.n_sup_networks = n_sup_networks
+        self.recon_loss = recon_loss
+        self.recon_weight = recon_weight
+        self.sup_recon_type = sup_recon_type
+        self.sup_smoothness_weight = sup_smoothness_weight
+        self.sup_recon_weight = sup_recon_weight
+        self.verbose = verbose
+
+        self.recon_loss_f = self.get_recon_loss(recon_loss)
+
+        #Set correlation constraints
+        if fixed_corr == None:
+            self.fixed_corr = ["n/a" for sup_net in range(self.n_sup_networks)]
+        elif type(fixed_corr)!=list:
+            if fixed_corr.lower() == "positive":
+                self.fixed_corr = ["positive"]
+            elif fixed_corr.lower() == "negative":
+                self.fixed_corr = ["negative"]
+            elif fixed_corr.lower() == "n/a":
+                self.fixed_corr = ["n/a"]
+            else:
+                raise ValueError("fixed corr must be a list or in {`positive`,`negative`,`n/a`}")
+        else:
+            assert len(fixed_corr) == len(range(self.n_sup_networks))
+            self.fixed_corr = fixed_corr
+
+        self.feature_groups = feature_groups
+        if feature_groups is not None and group_weights is None:
+            group_weights = []
+            for idx,(lb,ub) in enumerate(feature_groups):
+                group_weights.append((feature_groups[-1][-1] - feature_groups[0][0])/(ub - lb))
+            self.group_weights = group_weights
+        else:
+            self.group_weights = group_weights
+
+        if device == 'auto':
+            self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        else:
+            self.device = device
+
+    def _initialize_NMF(self,dim_in):
+        """
+        Instantiates the NMF decoder and moves the NMF_Base instance to self.device
+
+        Parameters
+        ----------
+        dim_in : int
+            Number of total features
+        """
+        self.W_nmf = nn.Parameter(torch.rand(self.n_components,dim_in))
+        self.to(self.device)
+
+    @staticmethod
+    def inverse_softplus(x, eps=1e-5):
+        '''
+        Gets the inverse softplus for sklearn model pretraining
+        '''
+        # Calculate inverse softplus
+        x_inv_softplus = np.log(np.exp(x+eps) - (1.0 - eps))
+        
+        # Return inverse softplus
+        return x_inv_softplus
+
+    def get_W_nmf(self):
+        """
+        Passes the W_nmf parameter through a softplus function to make it non-negative
+        """
+        return nn.Softplus()(self.W_nmf)
+
+    @torch.no_grad()
+    def get_recon_loss(self,recon_loss):
+        """
+        Returns the reconstruction loss function
+
+        Parameters
+        ----------
+        recon_loss : str in {"MSE","IS"}
+            Identifies which loss function to use
+        """
+        if recon_loss == "MSE":
+            return nn.MSELoss()
+        elif recon_loss == "IS":
+            return BetaDivLoss(beta=0,reduction="mean")
+        else:
+            raise ValueError(f"{recon_loss} is not supported")
+
+    @torch.no_grad()
+    def get_optim(self,optim_name):
+        '''
+        returns a torch optimizer based on text input from the user
+        '''
+        if optim_name == "AdamW":
+            return torch.optim.AdamW
+        elif optim_name == "Adam":
+            return torch.optim.Adam
+        elif optim_name == "SGD":
+            return torch.optim.SGD
+        else:
+            raise ValueError(f"{optim_name} is not supported")
+
+    @torch.no_grad()
+    def pretrain_NMF(self,X,y,nmf_max_iter=100):
+        """
+        Trains an unsupervised NMF model and sorts components by predictiveness for corresponding tasks.
+        Saved NMF components are stored as a member variable self.W_nmf. Sklearn NMF model is saved as
+        NMF_init.
+
+        Parameters
+        ----------
+        X : numpy.ndarray
+            Input features
+            Shape: ``[n_samps,n_features]``
+        
+        y : numpy.ndarray
+            Input labels
+            Shape: ``[n_samps,n_sup_networks]``
+
+        nmf_max_iter : int
+            Maximum iterations for convergence using sklearn.decomposition.NMF
+        
+        Returns
+        ---------
+
+        None
+        """
+
+        if self.verbose: print("Pretraining NMF...")
+
+        # Initialize the model - solver corresponds to defined recon loss
+        if self.recon_loss == "IS":
+            self.NMF_init = NMF(n_components=self.n_components,solver="mu",beta_loss="itakura-saito",init='nndsvda',max_iter=nmf_max_iter)
+        else:
+            self.NMF_init = NMF(n_components=self.n_components,max_iter=nmf_max_iter,init="nndsvd")
+
+        #Fit the model
+        s_NMF = self.NMF_init.fit_transform(X)
+
+        #define arrays for storing model predictive information
+        selected_networks = []
+        selected_aucs = []
+        final_network_order = []
+
+        #Find the most predictive component for each task - the first task gets priority
+        for sup_net in range(self.n_sup_networks):
+            
+            #Prep labels and set auc storage
+            class_auc_list = []
+
+            #Create progress bar if verbose
+            if self.verbose:
+                print("Identifying predictive components for supervised network {}".format(sup_net))
+                component_iter = tqdm(range(self.n_components))
+            else:
+                component_iter = range(self.n_components)
+
+            #Find each components AUC for the current task
+            for component in component_iter:
+                s_pos = s_NMF[y[:,sup_net]==1,component].reshape(-1,1)
+                s_neg = s_NMF[y[:,sup_net]==0,component].reshape(-1,1)
+                U,_ = mannwhitneyu(s_pos,s_neg)
+                U = U.squeeze()
+                auc = U/(len(s_pos)*len(s_neg))
+
+                class_auc_list.append(auc)
+
+            class_auc_list = np.array(class_auc_list) 
+
+            #Sort AUC predictions based on correlations
+            predictive_order = np.argsort(np.abs(class_auc_list - 0.5))[::-1]
+            positive_predictive_order = np.argsort(class_auc_list)[::-1]
+            negative_predictive_order = np.argsort(1-class_auc_list)[::-1]
+
+            #Ignore components that have been used for previous supervised tasks
+            if len(selected_networks) > 0:
+                for taken_network in selected_networks:
+                    predictive_order = predictive_order[predictive_order != taken_network]
+                    positive_predictive_order = positive_predictive_order[positive_predictive_order != taken_network]
+                    negative_predictive_order = negative_predictive_order[negative_predictive_order != taken_network]
+
+            #Select the component based on predictive correlation
+            if self.fixed_corr[sup_net]=="n/a":
+                current_net = predictive_order[0]
+                
+            elif self.fixed_corr[sup_net].lower()=="positive":
+                current_net = positive_predictive_order[0]
+
+            elif self.fixed_corr[sup_net].lower()=="negative":
+                current_net = negative_predictive_order[0]
+
+            current_auc = class_auc_list[current_net.astype(int)]
+
+            #Declare the selected network and save the network and chosen AUCs
+            if self.verbose:
+                print("Selecting network: {} with auc {} for sup net {} using constraint {} correlation".format(current_net,current_auc,sup_net,self.fixed_corr[sup_net]))
+            selected_networks.append(current_net)
+            selected_aucs.append(selected_aucs)
+            predictive_order = predictive_order[predictive_order != current_net]
+            positive_predictive_order = positive_predictive_order[positive_predictive_order != current_net]
+            negative_predictive_order = negative_predictive_order[negative_predictive_order != current_net]
+        
+        #Save the selected networks and corresponding AUCs
+        self.skl_pretrain_networks_ = selected_networks
+        self.skl_pretrain_aucs_ = selected_aucs
+        final_network_order = selected_networks
+
+        #Get the final sorting of the networks for predictiveness
+        for idx,_ in enumerate(predictive_order):
+            final_network_order.append(predictive_order[idx])
+
+        #Save the final sorted components to the W_nmf parameter
+        sorted_NMF = self.NMF_init.components_[final_network_order]
+        self.W_nmf.data = torch.from_numpy(self.inverse_softplus(sorted_NMF.astype(np.float32))).to(self.device)
+
+    def get_sup_recon(self,s):
+        """
+        Returns the reconstruction of all of the supervised networks
+
+        Parameters
+        ----------
+        s : torch.Tensor.float()
+            Factor activation scores
+            Shape: ``[n_samps,n_components]``
+
+        Returns
+        -------
+        X_sup_recon : torch.Tensor.float()
+            Reconstruction using only supervised components
+            Shape: ``[n_samps,n_features]``
+        """
+        X_sup_recon = s[:,:self.n_sup_networks].view(-1,self.n_sup_networks) @ self.get_W_nmf()[:self.n_sup_networks,:].view(self.n_sup_networks,-1)
+        return X_sup_recon
+
+    def get_residual_scores(self,X,s):
+        """
+        Returns the supervised score values that would maximize reconstruction performance based
+        on the residual reconstruction.
+
+        s_h = (X - s_unsup @ W_unsup) @ w_sup.T @ (w_sup @ w_sup.T)^(-1)
+
+        Parameters
+        ----------
+        X : torch.Tensor
+            Ground truth features
+            Shape: ``[n_samples,n_features]``
+        
+        s : torch.Tensor
+            Factor activation scores
+            Shape: ``[n_samples,n_components]``
+        """
+        resid = (X-s[:,self.n_sup_networks:] @ self.get_W_nmf()[self.n_sup_networks:,:])
+        w_sup = self.get_W_nmf()[:self.n_sup_networks,:].view(self.n_sup_networks,-1)
+        s_h = resid @ w_sup.T @ torch.inverse(w_sup@w_sup.T)
+        return s_h
+
+    def residual_loss_f(self,s,s_h):
+        """
+        Loss function between supervised factor scores and the maximal values for
+        reconstruction. Factors scores are encouraged to be non-zero by the smoothness weight.
+
+        f(s,s_h) = ||s_sup - s_h||^2 / (1 - smoothness_weight * exp(-||s_h||^2))
+
+        Parameters
+        ----------
+        s : torch.Tensor
+            Factor activation scores
+            Shape: ``[n_samples,n_components]``
+
+        s_h : torch.Tensor
+            Factor scores that would minimize the reconstruction loss
+            Shape: ``[n_samples,n_components]``
+        
+        Returns
+        ---------
+        res_loss : torch.Tensor
+            Residual scores loss
+        """
+        res_loss = torch.norm(s[:,:self.n_sup_networks].view(-1,self.n_sup_networks)-s_h) / (1 - self.sup_smoothness_weight*torch.exp(-torch.norm(s_h)))
+        return res_loss
+
+    def get_weighted_recon_loss_f(self,X_pred,X_true):
+        """
+        Model training often involves multiple feature types such as Power and Directed Spectrum that
+        have vastly different feature counts (power: n_roi*n_freq, ds: n_roi*(n_roi-1)*n_freq).
+
+        This loss reweights the reconstruction of each feature group proportionally to the number of features
+        such that each feature type has roughly equal importance to the reconstruction.
+
+        Parameters
+        ----------
+        X_pred : torch.Tensor
+            Reconstructed features
+            Shape: ``[n_samps,n_features]``
+
+        X_true : torch.Tensor
+            Ground Truth Features
+            Shape: ``[n_samps,n_features]``
+
+        Returns
+        ---------
+        recon_loss : torch.Tensor
+            Weighted reconstruction loss for each feature
+        """
+        recon_loss = 0.0
+        for weight,(lb,ub) in zip(self.group_weights,self.feature_groups):
+            recon_loss += weight * self.recon_loss_f(X_pred[:,lb:ub],X_true[:,lb:ub])
+
+        return recon_loss
+
+    def eval_recon_loss(self,X_pred,X_true):
+        """
+        If using feature groups, returns weighted recon loss
+        Else, returns unweighted recon loss
+
+        Parameters
+        ----------
+        X_pred : torch.Tensor
+            Reconstructed features
+            Shape: ``[n_samps,n_features]``
+
+        X_true : torch.Tensor
+            Ground Truth Features
+            Shape: ``[n_samps,n_features]``
+
+        Returns
+        ---------
+        recon_loss : torch.Tensor
+            Weighted or Unweighted recon loss
+        """
+        if self.feature_groups is None:
+            recon_loss = self.recon_loss_f(X_pred,X_true)
+        else:
+            recon_loss = self.get_weighted_recon_loss_f(X_pred,X_true)
+
+        return recon_loss
+
+    def NMF_decoder_forward(self,X,s):
+        """
+        NMF Decoder forward pass
+
+        Parameters
+        ----------
+        X : torch.Tensor
+            Input Features
+            Shape: ``[n_samps,n_features]``
+
+        s : torch.Tensor
+            Encoder embeddings / factor score activations
+            Shape: ``[n_samps,n_components]``
+
+        Returns
+        -------
+        recon_loss : torch.Tensor
+            Whole data recon loss + supervised recon loss
+        """
+        recon_loss = 0.0
+
+        X_recon = s @ self.get_W_nmf()
+
+        recon_loss += self.recon_weight*self.eval_recon_loss(X_recon,X)
+
+        if self.sup_recon_type == "Residual":
+            s_h = self.get_residual_scores(X,s)
+            sup_recon_loss = self.residual_loss_f(s,s_h)
+        elif self.sup_recon_type == "All":
+            X_recon = self.get_sup_recon(s)
+            sup_recon_loss = self.recon_loss_f(X_recon,X)
+
+        recon_loss += self.sup_recon_weight*sup_recon_loss
+
+        return recon_loss
+
+    @torch.no_grad()
+    def get_comp_recon(self,s,component):
+        """
+        Gets the reconstruction for a specific component
+
+        Parameters
+        ----------
+        s : torch.Tensor
+            Encoder embeddings / factor score activations
+            Shape: ``[n_samps,n_components]``
+
+        component : int, 0 <= component < n_components
+            Component to use for the reconstruction
+
+        Returns
+        ---------
+        X_recon : numpy.ndarray
+            Reconstruction using a specific component
+        """
+        X_recon = s[:,component].view(-1,1) @ self.get_W_nmf()[component,:].view(1,-1)
+        return X_recon.detach().cpu().numpy()
+
+    @torch.no_grad()
+    def get_all_comp_recon(self,s):
+        """
+        Gets the reconstruction for all components
+
+        Parameters
+        ----------
+        s : torch.Tensor
+            Encoder embeddings / factor score activations
+            Shape: ``[n_samps,n_components]``
+
+        Returns
+        ---------
+        X_recon : numpy.ndarray
+            Reconstruction using a specific component
+        """
+        X_recon = s @ self.get_W_nmf()
+        return X_recon
+    @torch.no_grad()
+    def get_factor(self,component):
+        """
+        Returns the numpy array for the corresponding factor
+
+        Parameters
+        ----------
+        component : int, 0 <= component < n_components
+            Component to use for the reconstruction
+
+        Returns
+        ---------
+        factor : np.ndarray
+            Factor from W_nmf
+        """
+        return self.get_W_nmf()[component,:].detach().cpu().numpy()

--- a/lpne/plotting/plot_db.py
+++ b/lpne/plotting/plot_db.py
@@ -13,13 +13,24 @@ from scipy.stats import sem
 EPS = 1e-7
 
 
-
-def plot_db(features, freqs, labels, groups, rois=None, colors=None,
-    mode='abs', n_sem=2, min_quantile=0.05, sem_alpha=0.5, lw=1.0,
-    figsize=(8,8), fn='temp.pdf'):
+def plot_db(
+    features,
+    freqs,
+    labels,
+    groups,
+    rois=None,
+    colors=None,
+    mode="abs",
+    n_sem=2,
+    min_quantile=0.05,
+    sem_alpha=0.5,
+    lw=1.0,
+    figsize=(8, 8),
+    fn="temp.pdf",
+):
     """
     Plot cross power in decibels for the labels, averaged over groups.
-    
+
     Parameters
     ----------
     features : numpy.ndarray
@@ -54,7 +65,7 @@ def plot_db(features, freqs, labels, groups, rois=None, colors=None,
     assert features.shape[1] == len(freqs)
     assert features.shape[2] == features.shape[3]
     # Remove NaNs.
-    idx = np.argwhere(np.isnan(features).sum(axis=(1,2,3)) == 0).flatten()
+    idx = np.argwhere(np.isnan(features).sum(axis=(1, 2, 3)) == 0).flatten()
     features, labels, groups = features[idx], labels[idx], groups[idx]
     # Get unique groups and labels.
     unique_groups = np.unique(groups)
@@ -64,11 +75,9 @@ def plot_db(features, freqs, labels, groups, rois=None, colors=None,
         colors = list(TABLEAU_COLORS)
     # Convert to decibels.
     db_features = _to_db(features, freqs)
-    if mode == 'diff':
+    if mode == "diff":
         db_features -= np.mean(db_features, axis=0, keepdims=True)
-    group_avgs = np.zeros(
-            (len(unique_labels),len(unique_groups)) + features.shape[1:]
-    )
+    group_avgs = np.zeros((len(unique_labels), len(unique_groups)) + features.shape[1:])
     for i, group in enumerate(unique_groups):
         idx_1 = np.argwhere(groups == group).flatten()
         for j, label in enumerate(unique_labels):
@@ -76,60 +85,57 @@ def plot_db(features, freqs, labels, groups, rois=None, colors=None,
             idx = np.intersect1d(idx_1, idx_2)
             if len(idx) == 0:
                 continue
-            group_avgs[j,i] = np.mean(db_features[idx], axis=0)
-    if mode == 'diff':
+            group_avgs[j, i] = np.mean(db_features[idx], axis=0)
+    if mode == "diff":
         ymin = None
     else:
         ymin = np.quantile(group_avgs, min_quantile)
     n_roi = features.shape[2]
     if rois is not None:
-        pretty_rois = [roi.replace('_', ' ') for roi in rois]
+        pretty_rois = [roi.replace("_", " ") for roi in rois]
     _, axarr = plt.subplots(nrows=n_roi, ncols=n_roi, figsize=figsize)
     for i in range(n_roi):
         for j in range(n_roi):
             for k in range(len(unique_labels)):
-                mean_val = np.mean(group_avgs[k], axis=0)[:,i,j]
-                err = n_sem * sem(group_avgs[k], axis=0)[:,i,j]
-                axarr[i,j].plot(
+                mean_val = np.mean(group_avgs[k], axis=0)[:, i, j]
+                err = n_sem * sem(group_avgs[k], axis=0)[:, i, j]
+                axarr[i, j].plot(
                     freqs,
                     mean_val,
                     c=colors[k % len(colors)],
                     lw=lw,
                 )
-                axarr[i,j].fill_between(
+                axarr[i, j].fill_between(
                     freqs,
-                    mean_val-err,
-                    mean_val+err,
+                    mean_val - err,
+                    mean_val + err,
                     fc=colors[k % len(colors)],
                     alpha=sem_alpha,
                 )
-            for direction in ['top', 'right']:
-                axarr[i,j].spines[direction].set_visible(False)
-            plt.sca(axarr[i,j])
+            for direction in ["top", "right"]:
+                axarr[i, j].spines[direction].set_visible(False)
+            plt.sca(axarr[i, j])
             plt.xticks([])
             plt.yticks([])
             plt.ylim(ymin, None)
             if (rois is not None) and j == 0:
-                    plt.sca(axarr[i,j])
-                    plt.ylabel(pretty_rois[i], size='xx-small', rotation=30)
-            if (rois is not None) and i == n_roi-1:
-                plt.sca(axarr[i,j])
-                plt.xlabel(pretty_rois[j], size='xx-small', rotation=30)
+                plt.sca(axarr[i, j])
+                plt.ylabel(pretty_rois[i], size="xx-small", rotation=30)
+            if (rois is not None) and i == n_roi - 1:
+                plt.sca(axarr[i, j])
+                plt.xlabel(pretty_rois[j], size="xx-small", rotation=30)
     plt.savefig(fn)
-    plt.close('all')
-
+    plt.close("all")
 
 
 def _to_db(arr, freqs):
-    db_arr = arr / (EPS + freqs.reshape(1,-1,1,1))
+    db_arr = arr / (EPS + freqs.reshape(1, -1, 1, 1))
     db_arr = 10.0 * np.log10(db_arr + EPS)
     return db_arr
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/plotting/plot_factor.py
+++ b/lpne/plotting/plot_factor.py
@@ -10,8 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 
-
-def plot_factor(factor, rois, color=None, alpha=1.0, fn='temp.pdf'):
+def plot_factor(factor, rois, color=None, alpha=1.0, fn="temp.pdf"):
     """
     Plot power feature factor in a square grid.
 
@@ -30,16 +29,15 @@ def plot_factor(factor, rois, color=None, alpha=1.0, fn='temp.pdf'):
     """
     assert factor.ndim == 2, f"len({factor.shape}) != 2"
     plot_factors(
-            factor.reshape(1,factor.shape[0],factor.shape[1]),
-            rois,
-            colors=color if color is None else [color],
-            alpha=alpha,
-            fn=fn,
+        factor.reshape(1, factor.shape[0], factor.shape[1]),
+        rois,
+        colors=color if color is None else [color],
+        alpha=alpha,
+        fn=fn,
     )
 
 
-
-def plot_factors(factors, rois, colors=None, alpha=0.6, fn='temp.pdf'):
+def plot_factors(factors, rois, colors=None, alpha=0.6, fn="temp.pdf"):
     """
     Plot power feature factors in a square grid.
 
@@ -59,57 +57,55 @@ def plot_factors(factors, rois, colors=None, alpha=0.6, fn='temp.pdf'):
     assert factors.ndim == 3, f"len({factors.shape}) != 3"
     if colors is None:
         colors = list(TABLEAU_COLORS)
-    pretty_rois = [roi.replace('_', ' ') for roi in rois]
+    pretty_rois = [roi.replace("_", " ") for roi in rois]
     temp = 1.05 * np.max(np.abs(factors))
     ylim = (-temp, temp)
     n = len(rois)
-    factors = factors.reshape(len(factors),n*(n+1)//2,-1)
+    factors = factors.reshape(len(factors), n * (n + 1) // 2, -1)
     freqs = np.arange(factors.shape[2])
-    _, axarr = plt.subplots(n,n)
+    _, axarr = plt.subplots(n, n)
     for f in range(len(factors)):
         color = colors[f % len(colors)]
         for i in range(n):
-            for j in range(i+1):
-                idx = (i * (i+1)) // 2 + j
-                axarr[i,j].fill_between(
-                        freqs,
-                        factors[f,idx],
-                        fc=color,
-                        alpha=alpha,
+            for j in range(i + 1):
+                idx = (i * (i + 1)) // 2 + j
+                axarr[i, j].fill_between(
+                    freqs,
+                    factors[f, idx],
+                    fc=color,
+                    alpha=alpha,
                 )
-                for dir in axarr[i,j].spines:
-                    axarr[i,j].spines[dir].set_visible(False)
-                plt.sca(axarr[i,j])
+                for dir in axarr[i, j].spines:
+                    axarr[i, j].spines[dir].set_visible(False)
+                plt.sca(axarr[i, j])
                 plt.xticks([])
                 plt.yticks([])
                 plt.ylim(ylim)
                 if j < i:
-                    axarr[j,i].fill_between(
-                            freqs,
-                            factors[f,idx],
-                            fc=color,
-                            alpha=alpha,
+                    axarr[j, i].fill_between(
+                        freqs,
+                        factors[f, idx],
+                        fc=color,
+                        alpha=alpha,
                     )
-                    for dir in axarr[i,j].spines:
-                        axarr[j,i].spines[dir].set_visible(False)
-                    plt.sca(axarr[j,i])
+                    for dir in axarr[i, j].spines:
+                        axarr[j, i].spines[dir].set_visible(False)
+                    plt.sca(axarr[j, i])
                     plt.xticks([])
                     plt.yticks([])
                     plt.ylim(ylim)
                 if j == 0:
-                    plt.sca(axarr[i,j])
-                    plt.ylabel(pretty_rois[i], size='xx-small', rotation=30)
-                if i == n-1:
-                    plt.sca(axarr[i,j])
-                    plt.xlabel(pretty_rois[j], size='xx-small', rotation=30)
+                    plt.sca(axarr[i, j])
+                    plt.ylabel(pretty_rois[i], size="xx-small", rotation=30)
+                if i == n - 1:
+                    plt.sca(axarr[i, j])
+                    plt.xlabel(pretty_rois[j], size="xx-small", rotation=30)
     plt.savefig(fn)
-    plt.close('all')
+    plt.close("all")
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/plotting/plot_lfps.py
+++ b/lpne/plotting/plot_lfps.py
@@ -12,10 +12,19 @@ from scipy.stats import zscore
 import lpne
 
 
-
-def plot_lfps(lfps, rois=None, t1=0.0, t2=None, fs=1000, y_space=4.0,
-    alpha=0.85, lw=1.0, window_duration=None, show_windows=True,
-    fn='temp.pdf'):
+def plot_lfps(
+    lfps,
+    rois=None,
+    t1=0.0,
+    t2=None,
+    fs=1000,
+    y_space=4.0,
+    alpha=0.85,
+    lw=1.0,
+    window_duration=None,
+    show_windows=True,
+    fn="temp.pdf",
+):
     """
     Plot the LFPs in the specified time range.
 
@@ -56,14 +65,14 @@ def plot_lfps(lfps, rois=None, t1=0.0, t2=None, fs=1000, y_space=4.0,
     else:
         i2 = min(int(fs * t2), len(lfps[rois[0]]))
     t2 = i2 / fs
-    t_vals = np.linspace(t1, t2, i2-i1)
+    t_vals = np.linspace(t1, t2, i2 - i1)
     # Plot.
     lfp_num = 0
     nan_bar = None
     for roi in rois:
         # Plot the single channel.
         trace = _zscore(lfps[roi][i1:i2])
-        plt.plot(t_vals, lfp_num*y_space+trace, lw=lw, alpha=alpha)
+        plt.plot(t_vals, lfp_num * y_space + trace, lw=lw, alpha=alpha)
         if nan_bar is None:
             nan_bar = np.zeros(len(trace), dtype=int)
         nan_trace = np.isnan(trace)
@@ -71,49 +80,49 @@ def plot_lfps(lfps, rois=None, t1=0.0, t2=None, fs=1000, y_space=4.0,
         idx = np.argwhere(nan_trace > 0).flatten()
         # Plot the channel's outliers (NaNs) on top of that channel.
         if len(idx) > 0:
-            y_vals = [lfp_num*y_space] * len(idx)
-            plt.scatter(t_vals[idx], y_vals, c='k', s=4.0)
+            y_vals = [lfp_num * y_space] * len(idx)
+            plt.scatter(t_vals[idx], y_vals, c="k", s=4.0)
         lfp_num += 1
     # Plot the overall outliers.
     idx = np.argwhere(nan_bar > 0).flatten()
     if len(idx) > 0:
         if window_duration is None:
             # Plot as scatters if we don't have window information.
-            plt.scatter(t_vals[idx], [-2*y_space]*len(idx), c='k')
+            plt.scatter(t_vals[idx], [-2 * y_space] * len(idx), c="k")
         else:
             # Otherwise mark out entire windows at a time.
             i = i1
             window_samp = int(fs * window_duration)
-            temp_y = [-2*y_space]*2
+            temp_y = [-2 * y_space] * 2
             while i + window_samp <= i2:
-                if nan_bar[i-i1:i-i1+window_samp].sum() > 0:
+                if nan_bar[i - i1 : i - i1 + window_samp].sum() > 0:
                     plt.plot(
-                            [t_vals[i-i1], t_vals[i-i1+window_samp]],
-                            temp_y,
-                            c='k',
-                            solid_capstyle='butt',
-                            lw=2,
+                        [t_vals[i - i1], t_vals[i - i1 + window_samp]],
+                        temp_y,
+                        c="k",
+                        solid_capstyle="butt",
+                        lw=2,
                     )
                 i += window_samp
-    pretty_rois = [roi.replace('_', ' ') for roi in rois]
+    pretty_rois = [roi.replace("_", " ") for roi in rois]
     plt.yticks(
-            y_space*np.arange(len(rois)),
-            pretty_rois,
-            size='xx-small',
-            rotation=30,
+        y_space * np.arange(len(rois)),
+        pretty_rois,
+        size="xx-small",
+        rotation=30,
     )
     ax = plt.gca()
-    for dir in ['top', 'left', 'right']:
+    for dir in ["top", "left", "right"]:
         ax.spines[dir].set_visible(False)
     if show_windows and window_duration is not None:
-        i1 = int(np.ceil(t1/window_duration))
-        i2 = 1 + int(np.floor(t2/window_duration))
-        window_ts = [window_duration*i for i in range(i1,i2)]
+        i1 = int(np.ceil(t1 / window_duration))
+        i2 = 1 + int(np.floor(t2 / window_duration))
+        window_ts = [window_duration * i for i in range(i1, i2)]
         for window_t in window_ts:
-            plt.axvline(x=window_t, c='k', lw=1.0, ls='--')
-    plt.xlabel('Time (s)')
+            plt.axvline(x=window_t, c="k", lw=1.0, ls="--")
+    plt.xlabel("Time (s)")
     plt.savefig(fn)
-    plt.close('all')
+    plt.close("all")
 
 
 def _zscore(trace):
@@ -126,8 +135,7 @@ def _zscore(trace):
     return temp
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
 
 

--- a/lpne/plotting/plot_power.py
+++ b/lpne/plotting/plot_power.py
@@ -11,8 +11,7 @@ import numpy as np
 import warnings
 
 
-
-def plot_power(power, rois, fn='temp.pdf'):
+def plot_power(power, rois, fn="temp.pdf"):
     """
     Plot power features in a square grid.
 
@@ -25,47 +24,45 @@ def plot_power(power, rois, fn='temp.pdf'):
     fn : str, optional
         Image filename
     """
-    pretty_rois = [roi.replace('_', ' ') for roi in rois]
+    pretty_rois = [roi.replace("_", " ") for roi in rois]
     if np.isnan(power).sum() > 0:
         warnings.warn("Power contains NaNs! Returning...")
         return
-    ylim = (-0.05*np.max(power), 1.05*np.max(power))
-    n = int(round((-1 + np.sqrt(1+8*power.shape[0]))/2))
+    ylim = (-0.05 * np.max(power), 1.05 * np.max(power))
+    n = int(round((-1 + np.sqrt(1 + 8 * power.shape[0])) / 2))
     assert n == len(rois)
     assert n > 1
-    fig, axarr = plt.subplots(n,n)
+    fig, axarr = plt.subplots(n, n)
     for i in range(n):
-        for j in range(i+1):
-            idx = (i * (i+1)) // 2 + j
-            axarr[i,j].fill_between(np.arange(len(power[0])), power[idx])
-            for dir in axarr[i,j].spines:
-                axarr[i,j].spines[dir].set_visible(False)
-            plt.sca(axarr[i,j])
+        for j in range(i + 1):
+            idx = (i * (i + 1)) // 2 + j
+            axarr[i, j].fill_between(np.arange(len(power[0])), power[idx])
+            for dir in axarr[i, j].spines:
+                axarr[i, j].spines[dir].set_visible(False)
+            plt.sca(axarr[i, j])
             plt.xticks([])
             plt.yticks([])
             plt.ylim(ylim)
             if j < i:
-                axarr[j,i].fill_between(np.arange(len(power[0])), power[idx])
-                for dir in axarr[i,j].spines:
-                    axarr[j,i].spines[dir].set_visible(False)
-                plt.sca(axarr[j,i])
+                axarr[j, i].fill_between(np.arange(len(power[0])), power[idx])
+                for dir in axarr[i, j].spines:
+                    axarr[j, i].spines[dir].set_visible(False)
+                plt.sca(axarr[j, i])
                 plt.xticks([])
                 plt.yticks([])
                 plt.ylim(ylim)
             if j == 0:
-                plt.sca(axarr[i,j])
-                plt.ylabel(pretty_rois[i], size='xx-small', rotation=30)
-            if i == n-1:
-                plt.sca(axarr[i,j])
-                plt.xlabel(pretty_rois[j], size='xx-small', rotation=30)
+                plt.sca(axarr[i, j])
+                plt.ylabel(pretty_rois[i], size="xx-small", rotation=30)
+            if i == n - 1:
+                plt.sca(axarr[i, j])
+                plt.xlabel(pretty_rois[j], size="xx-small", rotation=30)
     plt.savefig(fn)
-    plt.close('all')
+    plt.close("all")
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/plotting/plot_spec.py
+++ b/lpne/plotting/plot_spec.py
@@ -15,21 +15,29 @@ EPSILON = 1e-8
 
 
 DEFAULT_STFT_PARAMS = {
-    'detrend': 'constant',
-    'window': 'hann',
-    'nperseg': 1024,
-    'noverlap': 896,
-    'nfft': None,
+    "detrend": "constant",
+    "window": "hann",
+    "nperseg": 1024,
+    "noverlap": 896,
+    "nfft": None,
 }
 """Default parameters sent to ``scipy.signal.stft``"""
 
 
-
-def plot_spec(lfp, fs, t1=0.0, t2=None, max_freq=55.0, stft_params={},
-    roi=None, min_max_quantiles=[0.005,0.995], fn='temp.pdf'):
+def plot_spec(
+    lfp,
+    fs,
+    t1=0.0,
+    t2=None,
+    max_freq=55.0,
+    stft_params={},
+    roi=None,
+    min_max_quantiles=[0.005, 0.995],
+    fn="temp.pdf",
+):
     """
     Plot a spectrogram of the given LFP.
-    
+
     Parameters
     ----------
     lfp : numpy.ndarray
@@ -69,29 +77,28 @@ def plot_spec(lfp, fs, t1=0.0, t2=None, max_freq=55.0, stft_params={},
     idx = np.searchsorted(f, max_freq)
     f = f[:idx]
     Zxx = Zxx[:idx]
-    Zxx = np.log(np.abs(Zxx)+EPSILON)
+    Zxx = np.log(np.abs(Zxx) + EPSILON)
     vmin, vmax = np.quantile(Zxx, min_max_quantiles)
     # Plot the spectrogram.
     plt.imshow(
-            Zxx, 
-            extent=[t[0], t[-1], f[0], f[-1]],
-            origin='lower',
-            aspect='auto',
-            vmin=vmin,
-            vmax=vmax,
+        Zxx,
+        extent=[t[0], t[-1], f[0], f[-1]],
+        origin="lower",
+        aspect="auto",
+        vmin=vmin,
+        vmax=vmax,
     )
     plt.ylabel("Frequency (Hz)")
     plt.xlabel("Time (s)")
     plt.colorbar()
     if roi is not None:
-        pretty_roi = roi.replace('_', ' ')
+        pretty_roi = roi.replace("_", " ")
         plt.title(pretty_roi)
     plt.savefig(fn)
-    plt.close('all')
+    plt.close("all")
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
 
 

--- a/lpne/plotting/power_movie.py
+++ b/lpne/plotting/power_movie.py
@@ -7,9 +7,11 @@ __date__ = "August 2021 - July 2022"
 
 import numpy as np
 import matplotlib.pyplot as plt
+
 try:
     from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
     from moviepy.video.io.bindings import mplfig_to_npimage
+
     MOVIEPY_INSTALLED = True
 except ModuleNotFoundError:
     MOVIEPY_INSTALLED = False
@@ -17,14 +19,22 @@ from tqdm import tqdm
 
 import lpne
 
-COLOR_1 = 'tab:blue'
-COLOR_2 = 'tab:orange'
+COLOR_1 = "tab:blue"
+COLOR_2 = "tab:orange"
 FONTSIZE = 12
 
 
-
-def make_power_movie(lfps, duration, window_duration, fs=1000, feature='power',
-    speed_factor=5, fps=10, model=None, fn='out.mp4'):
+def make_power_movie(
+    lfps,
+    duration,
+    window_duration,
+    fs=1000,
+    feature="power",
+    speed_factor=5,
+    fps=10,
+    model=None,
+    fn="out.mp4",
+):
     """
     Make a movie of LFP power features.
 
@@ -49,28 +59,28 @@ def make_power_movie(lfps, duration, window_duration, fs=1000, feature='power',
         Movie filename
     """
     assert MOVIEPY_INSTALLED, "moviepy needs to be installed!"
-    assert feature in ['power', 'dir_spec'], f"{feature} not valid!"
+    assert feature in ["power", "dir_spec"], f"{feature} not valid!"
     # Get the features.
     window_step = speed_factor / fps
     max_n_windows = int((duration - window_duration) / window_step)
     res = lpne.make_features(
-            lfps,
-            fs=fs,
-            window_duration=window_duration,
-            window_step=window_step,
-            max_n_windows=max_n_windows,
-            directed_spectrum=(feature == 'dir_spec'),
+        lfps,
+        fs=fs,
+        window_duration=window_duration,
+        window_step=window_step,
+        max_n_windows=max_n_windows,
+        directed_spectrum=(feature == "dir_spec"),
     )
     # Set up the plot.
-    if feature == 'power':
-        power = lpne.unsqueeze_triangular_array(res['power'], dim=1) #[w,r,r,f]
+    if feature == "power":
+        power = lpne.unsqueeze_triangular_array(res["power"], dim=1)  # [w,r,r,f]
     else:
-        power = res['dir_spec'] # [w,r,r,f]
+        power = res["dir_spec"]  # [w,r,r,f]
     # Get reconstructed volumes.
-    flag = (model is not None)
+    flag = model is not None
     if flag:
-        rec_power = model.reconstruct(np.transpose(power, [0,3,1,2]))
-        rec_power = np.transpose(rec_power, [0,2,3,1]) # [w,r,r,f]
+        rec_power = model.reconstruct(np.transpose(power, [0, 3, 1, 2]))
+        rec_power = np.transpose(rec_power, [0, 2, 3, 1])  # [w,r,r,f]
         alpha = 0.6
     else:
         alpha = 1.0
@@ -89,30 +99,30 @@ def make_power_movie(lfps, duration, window_duration, fs=1000, feature='power',
         to_remove = []
         for i in range(len(rois)):
             for j in range(len(rois)):
-                handle = axarr[i,j].fill_between(
-                        freqs,
-                        power[k,i,j],
-                        fc=COLOR_1,
-                        alpha=alpha,
+                handle = axarr[i, j].fill_between(
+                    freqs,
+                    power[k, i, j],
+                    fc=COLOR_1,
+                    alpha=alpha,
                 )
                 to_remove.append(handle)
                 if flag:
-                    handle = axarr[i,j].fill_between(
-                            freqs,
-                            rec_power[k,i,j],
-                            fc=COLOR_2,
-                            alpha=alpha,
+                    handle = axarr[i, j].fill_between(
+                        freqs,
+                        rec_power[k, i, j],
+                        fc=COLOR_2,
+                        alpha=alpha,
                     )
                     to_remove.append(handle)
         frames.append(mplfig_to_npimage(fig))
         for obj in to_remove:
             obj.remove()
     animation = ImageSequenceClip(frames, fps=fps)
-    if fn.endswith('.gif'):
+    if fn.endswith(".gif"):
         animation.write_gif(fn, fps=fps)
     else:
         animation.write_videofile(fn, fps=fps)
-    plt.close('all')
+    plt.close("all")
 
 
 def _set_up_plot(power, rois):
@@ -126,37 +136,36 @@ def _set_up_plot(power, rois):
     rois : list of str
         Shape: ``[f]``
     """
-    pretty_rois = [roi.replace('_', ' ') for roi in rois]
-    ylim = (-0.05*np.max(power), 1.05*np.max(power))
+    pretty_rois = [roi.replace("_", " ") for roi in rois]
+    ylim = (-0.05 * np.max(power), 1.05 * np.max(power))
     n = power.shape[1]
     assert n == len(rois), f"{n} != len({rois})"
-    fig, axarr = plt.subplots(n,n,figsize=(8,8))
+    fig, axarr = plt.subplots(n, n, figsize=(8, 8))
     for i in range(n):
-        for j in range(i+1):
-            for dir in axarr[i,j].spines:
-                axarr[i,j].spines[dir].set_visible(False)
-            plt.sca(axarr[i,j])
+        for j in range(i + 1):
+            for dir in axarr[i, j].spines:
+                axarr[i, j].spines[dir].set_visible(False)
+            plt.sca(axarr[i, j])
             plt.xticks([])
             plt.yticks([])
             plt.ylim(ylim)
             if j < i:
-                for dir in axarr[i,j].spines:
-                    axarr[j,i].spines[dir].set_visible(False)
-                plt.sca(axarr[j,i])
+                for dir in axarr[i, j].spines:
+                    axarr[j, i].spines[dir].set_visible(False)
+                plt.sca(axarr[j, i])
                 plt.xticks([])
                 plt.yticks([])
                 plt.ylim(ylim)
             if j == 0:
-                plt.sca(axarr[i,j])
-                plt.ylabel(pretty_rois[i], size='xx-small', rotation=30)
-            if i == n-1:
-                plt.sca(axarr[i,j])
-                plt.xlabel(pretty_rois[j], size='xx-small', rotation=30)
+                plt.sca(axarr[i, j])
+                plt.ylabel(pretty_rois[i], size="xx-small", rotation=30)
+            if i == n - 1:
+                plt.sca(axarr[i, j])
+                plt.xlabel(pretty_rois[j], size="xx-small", rotation=30)
     return fig, axarr
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
 
 

--- a/lpne/preprocess/channel_maps.py
+++ b/lpne/preprocess/channel_maps.py
@@ -12,12 +12,11 @@ import warnings
 
 
 IGNORED_KEYS = [
-    '__header__',
-    '__version__',
-    '__globals__',
+    "__header__",
+    "__version__",
+    "__globals__",
 ]
 """Ignored keys in the LFP data file"""
-
 
 
 def average_channels(lfps, channel_map, check_channel_map=True):
@@ -51,7 +50,7 @@ def average_channels(lfps, channel_map, check_channel_map=True):
             if roi in channel_map and channel_map[roi] == grouped_roi:
                 avg.append(lfps[roi].flatten())
         if len(avg) == 0:
-            warnings.warn( \
+            warnings.warn(
                 f"No channels to make grouped channel {grouped_roi}!",
             )
         else:
@@ -92,13 +91,12 @@ def get_default_channel_map(channels, combine_hemispheres=True):
     for channel in channels:
         if channel in IGNORED_KEYS:
             continue
-        if '_' not in channel:
+        if "_" not in channel:
             warnings.warn(
-                f"Expected an underscore in channel name: {channel}"
-                f", ignoring."
+                f"Expected an underscore in channel name: {channel}" f", ignoring."
             )
             continue
-        split_str = channel.split('_')
+        split_str = channel.split("_")
         try:
             temp = int(split_str[-1])
         except ValueError:
@@ -108,16 +106,16 @@ def get_default_channel_map(channels, combine_hemispheres=True):
             )
             continue
         if combine_hemispheres:
-            if len(split_str) < 3 or split_str[-2] not in ['L', 'R']:
+            if len(split_str) < 3 or split_str[-2] not in ["L", "R"]:
                 warnings.warn(
                     f"Unexpected channel name: {channel}"
                     f", no hemisphere indication. Ignoring."
                 )
                 continue
             else:
-                grouped_roi = '_'.join(split_str[:-2])
+                grouped_roi = "_".join(split_str[:-2])
         else:
-            grouped_roi = '_'.join(split_str[:-1])
+            grouped_roi = "_".join(split_str[:-1])
         channel_map[channel] = grouped_roi
     return channel_map
 
@@ -131,7 +129,7 @@ def get_excel_channel_map(channels, fn):
     * ``UserWarning`` if a channel present in ``channels`` is not present in
       the excel channel map. The channel is not included in the channel map
       in this case.
-    
+
     Parameters
     ----------
     channels : list of str
@@ -188,7 +186,7 @@ def remove_channels(channel_map, to_remove):
 def remove_channels_from_lfps(lfps, fn):
     """
     Remove channels specified in the CHANS file from the LFPs.
-    
+
     Parameters
     ----------
     lfps : dict
@@ -227,15 +225,15 @@ def get_removed_channels_from_file(fn):
         List of channels to remove.
     """
     assert isinstance(fn, str)
-    if fn.endswith('.mat'):
+    if fn.endswith(".mat"):
         # try:
         data = loadmat(fn)
         # except: for old .mat files in hdf5 format...
-        assert('CHANNAMES' in data), f"{fn} must contain CHANNAMES!"
-        assert('CHANACTIVE' in data), f"{fn} must contain CHANACTIVE!"
-        channel_active = data['CHANACTIVE'].flatten()
+        assert "CHANNAMES" in data, f"{fn} must contain CHANNAMES!"
+        assert "CHANACTIVE" in data, f"{fn} must contain CHANACTIVE!"
+        channel_active = data["CHANACTIVE"].flatten()
         channel_names = np.array(
-                [str(i[0]) for i in data['CHANNAMES'].flatten()],
+            [str(i[0]) for i in data["CHANNAMES"].flatten()],
         )
         idx = np.argwhere(channel_active == 0).flatten()
         return channel_names[idx].tolist()
@@ -263,10 +261,8 @@ def _check_channel_map(lfps, channel_map):
             warnings.warn(f"Channel {channel} is not present in LFPS!")
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/preprocess/channel_maps.py
+++ b/lpne/preprocess/channel_maps.py
@@ -2,11 +2,17 @@
 Channel maps are used to determine which channels to average together.
 
 """
-__date__ = "July 2021 - September 2022"
+__date__ = "July 2021 - October 2022"
 
 
 import numpy as np
-import pandas as pd
+
+try:
+    import pandas as pd
+
+    PANDAS_INSTALLED = True
+except ModuleNotFoundError:
+    PANDAS_INSTALLED = False
 from scipy.io import loadmat
 import warnings
 
@@ -142,6 +148,7 @@ def get_excel_channel_map(channels, fn):
     channel_map : dict
         Maps individual channel names to grouped channel names
     """
+    assert PANDAS_INSTALLED, "Pandas needs to be installed!"
     f = pd.read_excel(fn, index_col=False, header=None)
     channel_map_full = f.set_index(0).to_dict()[1]
     channel_map = {}

--- a/lpne/preprocess/filter.py
+++ b/lpne/preprocess/filter.py
@@ -9,19 +9,19 @@ import numpy as np
 from scipy.signal import butter, lfilter, iirnotch
 
 
-ORDER = 3 # Butterworth bandpass filter order
+ORDER = 3  # Butterworth bandpass filter order
 """Butterworth filter order"""
-LOWCUT = 0.5 # Butterworth bandpass filter parameter
+LOWCUT = 0.5  # Butterworth bandpass filter parameter
 """Default lowcut for filtering (Hz)"""
-HIGHCUT = 55.0 # Butterworth bandpass filter parameter
+HIGHCUT = 55.0  # Butterworth bandpass filter parameter
 """Default highcut for filtering (Hz)"""
-Q = 2.0 # Notch filter parameter
+Q = 2.0  # Notch filter parameter
 """Notch filter quality parameter"""
 
 
-
-def filter_signal(x, fs, lowcut=LOWCUT, highcut=HIGHCUT, q=Q, order=ORDER,
-    apply_notch_filters=True):
+def filter_signal(
+    x, fs, lowcut=LOWCUT, highcut=HIGHCUT, q=Q, order=ORDER, apply_notch_filters=True
+):
     """
     Apply a bandpass filter and notch filters to the signal.
 
@@ -56,8 +56,8 @@ def filter_signal(x, fs, lowcut=LOWCUT, highcut=HIGHCUT, q=Q, order=ORDER,
     x = _butter_bandpass_filter(x, lowcut, highcut, fs, order=order)
     # Remove electrical noise at 60Hz and harmonics.
     if apply_notch_filters:
-        for i, freq in enumerate(range(60,int(fs/2),60)):
-            b, a = iirnotch(freq, (i+1)*q, fs)
+        for i, freq in enumerate(range(60, int(fs / 2), 60)):
+            b, a = iirnotch(freq, (i + 1) * q, fs)
             x = lfilter(b, a, x)
     # Reintroduce NaNs.
     x[nan_mask] = np.nan
@@ -84,12 +84,12 @@ def filter_lfps(lfps, fs, lowcut=LOWCUT, highcut=HIGHCUT, q=Q, order=ORDER):
     """
     for channel in list(lfps.keys()):
         lfps[channel] = filter_signal(
-                lfps[channel],
-                fs,
-                lowcut=lowcut,
-                highcut=highcut,
-                q=q,
-                order=order,
+            lfps[channel],
+            fs,
+            lowcut=lowcut,
+            highcut=highcut,
+            q=q,
+            order=order,
         )
     return lfps
 
@@ -98,7 +98,7 @@ def _butter_bandpass(lowcut, highcut, fs, order=ORDER):
     nyq = 0.5 * fs
     low = lowcut / nyq
     high = highcut / nyq
-    b, a = butter(order, [low, high], btype='band')
+    b, a = butter(order, [low, high], btype="band")
     return b, a
 
 
@@ -108,8 +108,7 @@ def _butter_bandpass_filter(data, lowcut, highcut, fs, order=ORDER):
     return y
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
 
 

--- a/lpne/preprocess/normalize.py
+++ b/lpne/preprocess/normalize.py
@@ -10,8 +10,7 @@ import numpy as np
 EPSILON = 1e-6
 
 
-
-def normalize_features(power_features, partition=None, mode='median'):
+def normalize_features(power_features, partition=None, mode="median"):
     """
     Normalize the features.
 
@@ -45,16 +44,16 @@ def normalize_features(power_features, partition=None, mode='median'):
     if partition is None:
         idx = np.arange(len(power_features))
     else:
-        idx = partition['train']
+        idx = partition["train"]
     power_subset = power_features[idx]
     # Remove NaNs.
-    axes = tuple(i for i in range(1,power_subset.ndim))
+    axes = tuple(i for i in range(1, power_subset.ndim))
     power_subset = power_subset[np.sum(np.isnan(power_subset), axis=axes) == 0]
-    if mode == 'std':
+    if mode == "std":
         temp = np.std(power_subset)
-    elif mode == 'max':
+    elif mode == "max":
         temp = np.max(power_subset)
-    elif mode == 'median':
+    elif mode == "median":
         temp = np.median(power_subset)
     else:
         raise NotImplementedError(f"Mode {mode} not implemented!")
@@ -62,7 +61,7 @@ def normalize_features(power_features, partition=None, mode='median'):
     return power_features
 
 
-def normalize_lfps(lfps, mode='zscore'):
+def normalize_lfps(lfps, mode="zscore"):
     """
     Normalize the LFPs.
 
@@ -81,7 +80,7 @@ def normalize_lfps(lfps, mode='zscore'):
     lfps : dict
         Maps ROI names to waveforms.
     """
-    if mode == 'zscore':
+    if mode == "zscore":
         for channel in lfps:
             temp_lfp = lfps[channel]
             temp_lfp = temp_lfp[~np.isnan(temp_lfp)]
@@ -92,11 +91,8 @@ def normalize_lfps(lfps, mode='zscore'):
     return lfps
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/preprocess/outlier_detection.py
+++ b/lpne/preprocess/outlier_detection.py
@@ -12,15 +12,15 @@ from .filter import filter_signal
 
 DEFAULT_MAD_TRESHOLD = 15.0
 """Default median absolute deviation threshold for outlier detection"""
-LOWCUT = 30.0 # Butterworth bandpass filter parameter
+LOWCUT = 30.0  # Butterworth bandpass filter parameter
 """Default lowcut for filtering (Hz)"""
-HIGHCUT = 55.0 # Butterworth bandpass filter parameter
+HIGHCUT = 55.0  # Butterworth bandpass filter parameter
 """Default highcut for filtering (Hz)"""
 
 
-
-def mark_outliers(lfps, fs, lowcut=LOWCUT, highcut=HIGHCUT,
-    mad_threshold=DEFAULT_MAD_TRESHOLD):
+def mark_outliers(
+    lfps, fs, lowcut=LOWCUT, highcut=HIGHCUT, mad_threshold=DEFAULT_MAD_TRESHOLD
+):
     """
     Detect outlying samples in the LFPs.
 
@@ -45,24 +45,23 @@ def mark_outliers(lfps, fs, lowcut=LOWCUT, highcut=HIGHCUT,
         trace = np.copy(lfps[roi])
         # Filter the signal.
         trace = filter_signal(
-                trace,
-                fs,
-                lowcut=lowcut,
-                highcut=highcut,
-                apply_notch_filters=False,
+            trace,
+            fs,
+            lowcut=lowcut,
+            highcut=highcut,
+            apply_notch_filters=False,
         )
         # Subtract out the median and rectify.
         trace = np.abs(trace - np.median(trace))
         # Calculate the MAD and the treshold.
-        mad = np.median(trace) # median absolute deviation
+        mad = np.median(trace)  # median absolute deviation
         thresh = mad_threshold * mad
         # Mark outlying samples.
         lfps[roi][trace > thresh] = np.nan
     return lfps
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
 
 

--- a/lpne/utils/data.py
+++ b/lpne/utils/data.py
@@ -13,12 +13,11 @@ import warnings
 
 
 IGNORED_KEYS = [
-    '__header__',
-    '__version__',
-    '__globals__',
+    "__header__",
+    "__version__",
+    "__globals__",
 ]
 """Ignored keys in the LFP data file"""
-
 
 
 def load_lfps(fn):
@@ -36,11 +35,11 @@ def load_lfps(fn):
         Maps ROI names to LFP waveforms.
     """
     assert isinstance(fn, str)
-    if fn.endswith('.mat'):
+    if fn.endswith(".mat"):
         try:
             lfps = loadmat(fn)
         except NotImplementedError:
-            lfps = dict(h5py.File(fn, 'r'))
+            lfps = dict(h5py.File(fn, "r"))
     else:
         raise NotImplementedError(f"Cannot load file: {fn}")
     # Make sure all the channels are 1D float arrays.
@@ -72,12 +71,13 @@ def save_features(features, fn):
         Where to save the data. Supported file types: {'.npy'}
     """
     assert isinstance(fn, str)
-    if fn.endswith('.npy'):
+    if fn.endswith(".npy"):
         np.save(fn, features)
     else:
         raise NotImplementedError(f"Unsupported file type: {fn}")
 
-def load_features(fns, return_counts=False,feature="power"):
+
+def load_features(fns, return_counts=False, feature="power"):
     """
     Load the features saved in the given filenames.
 
@@ -101,19 +101,18 @@ def load_features(fns, return_counts=False,feature="power"):
     counts : list of int
         Number of windows in each file. Returned if `return_counts` is `True`.
     """
-    assert feature in ["power","dir_spec"], f"Unsupported feature: {feature}"
+    assert feature in ["power", "dir_spec"], f"Unsupported feature: {feature}"
     if isinstance(fns, str):
         fns = [fns]
     assert isinstance(fns, list)
     features, counts = [], []
     prev_rois = None
     for fn in fns:
-        assert fn.endswith('.npy'), f"Unsupported file type: {fn}"
+        assert fn.endswith(".npy"), f"Unsupported file type: {fn}"
         temp = np.load(fn, allow_pickle=True).item()
-        rois = temp['rois']
+        rois = temp["rois"]
         if prev_rois is not None:
-            assert prev_rois == rois, \
-                    f"Inconsitent ROIs: {rois} != {prev_rois}"
+            assert prev_rois == rois, f"Inconsitent ROIs: {rois} != {prev_rois}"
         prev_rois = rois
         features.append(temp[feature])
         counts.append(len(features[-1]))
@@ -146,7 +145,7 @@ def save_labels(labels, fn, overwrite=True):
     if isinstance(labels, list):
         labels = np.array(labels)
     assert isinstance(labels, np.ndarray)
-    if fn.endswith('.npy'):
+    if fn.endswith(".npy"):
         np.save(fn, labels)
     else:
         raise NotImplementedError(f"Unsupported file type: {fn}")
@@ -174,7 +173,7 @@ def load_labels(fn, soft_labels=False):
         Shape: [n_windows] or [n_windows,n_classes]
     """
     assert isinstance(fn, str)
-    if fn.endswith('.npy'):
+    if fn.endswith(".npy"):
         labels = np.load(fn)
     else:
         raise NotImplementedError(f"Unsupported file type: {fn}")
@@ -183,8 +182,9 @@ def load_labels(fn, soft_labels=False):
     return labels
 
 
-def load_features_and_labels(feature_fns, label_fns, group_func=None,
-    return_counts=False, soft_labels=False):
+def load_features_and_labels(
+    feature_fns, label_fns, group_func=None, return_counts=False, soft_labels=False
+):
     """
     Load the features and labels.
 
@@ -220,31 +220,35 @@ def load_features_and_labels(feature_fns, label_fns, group_func=None,
     counts : list of int
         Number of windows in each file. Returned if `return_counts` is `True`.
     """
-    assert group_func is None or isinstance(group_func, type(lambda x: x)), \
-            "group_func must either be None or a function!"
-    assert len(feature_fns) == len(label_fns), \
-            f"Expected the same number of feature and label filenames. " \
-            f"Found {len(feature_fns)} and {len(label_fns)}."
+    assert group_func is None or isinstance(
+        group_func, type(lambda x: x)
+    ), "group_func must either be None or a function!"
+    assert len(feature_fns) == len(label_fns), (
+        f"Expected the same number of feature and label filenames. "
+        f"Found {len(feature_fns)} and {len(label_fns)}."
+    )
     # Collect everything.
     features, labels, groups, counts = [], [], [], []
     prev_rois = None
     for i, (feature_fn, label_fn) in enumerate(zip(feature_fns, label_fns)):
         power, rois = load_features(feature_fn)
         if prev_rois is not None:
-            assert prev_rois == rois, \
-                    f"Inconsitent ROIs: {prev_rois} != {rois}" \
-                    f"\n\tFile 1: {feature_fns[i-1]}" \
-                    f"\n\tFile 2: {feature_fns[i]}"
+            assert prev_rois == rois, (
+                f"Inconsitent ROIs: {prev_rois} != {rois}"
+                f"\n\tFile 1: {feature_fns[i-1]}"
+                f"\n\tFile 2: {feature_fns[i]}"
+            )
         prev_rois = rois
         features.append(power)
         counts.append(len(power))
         labels.append(load_labels(label_fn))
-        assert len(power) == len(labels[-1]), \
-            f"Number of windows doesn't match for feature and label file!" \
-            f"\n\tFeatures: {feature_fn} (len({power.shape}))" \
+        assert len(power) == len(labels[-1]), (
+            f"Number of windows doesn't match for feature and label file!"
+            f"\n\tFeatures: {feature_fn} (len({power.shape}))"
             f"\n\tLabels: {label_fn} ({len(labels[-1])})"
+        )
         if group_func is not None:
-            groups.append([group_func(feature_fn)]*len(labels[-1]))
+            groups.append([group_func(feature_fn)] * len(labels[-1]))
     # Concatenate and return.
     features = np.concatenate(features, axis=0)
     labels = np.concatenate(labels, axis=0)
@@ -259,10 +263,8 @@ def load_features_and_labels(feature_fns, label_fns, group_func=None,
     return res
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/utils/data.py
+++ b/lpne/utils/data.py
@@ -77,8 +77,7 @@ def save_features(features, fn):
     else:
         raise NotImplementedError(f"Unsupported file type: {fn}")
 
-
-def load_features(fns, return_counts=False):
+def load_features(fns, return_counts=False,feature="power"):
     """
     Load the features saved in the given filenames.
 
@@ -88,17 +87,21 @@ def load_features(fns, return_counts=False):
         Where the data is saved. Supported file types: {'.npy'}
     return_counts : bool, optional
         Return the number of windows for each file.
+    feature : str, optional
+        Which feature in {"power","dir_spec"} to load.
 
     Returns
     -------
     features : numpy.ndarray
-        LFP power features
-        Shape: ``[n_windows] + feature_dims``
+        LFP power features or directed spectrum features.
+        Power Shape: ``[n_windows,(n_roi)*(n_roi+1)/2,n_freqs]``
+        Dir Spec Shape: ``[n_windows,n_roi,n_roi,n_freqs]``
     rois : list of str
         ROI names
     counts : list of int
         Number of windows in each file. Returned if `return_counts` is `True`.
     """
+    assert feature in ["power","dir_spec"], f"Unsupported feature: {feature}"
     if isinstance(fns, str):
         fns = [fns]
     assert isinstance(fns, list)
@@ -112,7 +115,7 @@ def load_features(fns, return_counts=False):
             assert prev_rois == rois, \
                     f"Inconsitent ROIs: {rois} != {prev_rois}"
         prev_rois = rois
-        features.append(temp['power'])
+        features.append(temp[feature])
         counts.append(len(features[-1]))
     features = np.concatenate(features, axis=0)
     if return_counts:

--- a/lpne/utils/utils.py
+++ b/lpne/utils/utils.py
@@ -382,6 +382,71 @@ def get_outlier_summary(lfps, fs, window_duration, top_n=6):
         msg += f"  {i+1}) {roi}: {numerator}/{n_windows} ({percent:.2f}%)\n"
     return msg
 
+def flatten_power_features(features,rois,f):
+    """
+    Returns a flattened cross power features congruous with the legacy format
+
+    Parameters
+    ----------
+    features : numpy.ndarray
+        LFP Directed Spectrum Features
+        Shape: ``[n_windows,n_freqs,n_roi,n_roi]``
+    
+    rois : list of str
+        Sorted list of ROI labels.
+
+    f : np.ndarray
+        Array of evaluated frequencies
+
+    Returns
+    -------
+    flat_features : numpy.ndarray
+        Flattened LFP Directed Spectrum Features sorted by feature type
+        Feature Interpretation: ``[n_windows, power features + causality features]``
+        Shape: ``[n_windows,n_roi*n_freqs + n_roi*(n_roi-1)*n_freqs]``
+    
+    feature_ids : list of str
+        List mapping flat_features index to a feature label ``<feature_id> <freq>``
+        Shape: ``[n_roi*n_freqs + n_roi*(n_roi-1)*n_freqs]
+
+    """
+
+
+    assert features.shape[-1] == len(rois), f"Shape mismatch between features and rois"
+    assert features.shape[1] == len(f), f"Shape mismatch between features and f"
+
+    n_rois = features.shape[-1]
+    n_freqs = features.shape[1]
+    n_flat_features = n_rois**2 * n_freqs
+
+    flat_features = np.zeros((features.shape[0],n_flat_features))
+    feature_ids = []
+
+    #Assign the power features
+    for roi_idx in range(n_rois):
+        flat_features[:,roi_idx*n_freqs:(roi_idx+1)*n_freqs] = features[:,:,roi_idx,roi_idx]
+        
+        for freq in f:
+            feature_id = f"{rois[roi_idx]} {freq}"
+            feature_ids.append(feature_id)
+    
+    #Assign the directed spectrum causality features
+    flat_idx = n_rois
+    for roi_idx_1 in range(n_rois):
+        for roi_idx_2 in range(n_rois):
+            if roi_idx_1 == roi_idx_2:
+                continue
+            else:
+                start_idx = flat_idx*n_freqs
+                stop_idx = (flat_idx+1)*n_freqs
+                flat_features[:,start_idx:stop_idx] = features[:,:,roi_idx_1,roi_idx_2]
+
+                for freq in f:
+                    feature_id = f"{rois[roi_idx_1]}->{rois[roi_idx_2]} {freq}"
+                    feature_ids.append(feature_id)
+
+
+    return flat_features, feature_ids
 def flatten_dir_spec_features(features,rois,f):
     """
     Returns a flattened directed spectrum congruous with the legacy format.

--- a/lpne/utils/utils.py
+++ b/lpne/utils/utils.py
@@ -382,6 +382,69 @@ def get_outlier_summary(lfps, fs, window_duration, top_n=6):
         msg += f"  {i+1}) {roi}: {numerator}/{n_windows} ({percent:.2f}%)\n"
     return msg
 
+def flatten_dir_spec_features(features,rois,f):
+    """
+    Returns a flattened directed spectrum congruous with the legacy format.
+
+    Parameters
+    ----------
+    features : numpy.ndarray
+        LFP Directed Spectrum Features
+        Shape: ``[n_windows,n_roi,n_roi,n_freqs]``
+    
+    rois : list of str
+        Sorted list of ROI labels.
+
+    f : np.ndarray
+        Array of evaluated frequencies
+
+    Returns
+    -------
+    flat_features : numpy.ndarray
+        Flattened LFP Directed Spectrum Features sorted by feature type
+        Feature Interpretation: ``[n_windows, power features + causality features]``
+        Shape: ``[n_windows,n_roi*n_freqs + n_roi*(n_roi-1)*n_freqs]``
+    
+    feature_ids : list of str
+        List mapping flat_features index to a feature label ``<feature_id> <freq>``
+        Shape: ``[n_roi*n_freqs + n_roi*(n_roi-1)*n_freqs]
+    """
+
+    assert features.shape[1] == len(rois), f"Shape mismatch between features and rois"
+    assert features.shape[-1] == len(f), f"Shape mismatch between features and f"
+
+    n_rois = features.shape[1]
+    n_freqs = features.shape[-1]
+    n_flat_features = n_rois**2 * n_freqs
+
+    flat_features = np.zeros((features.shape[0],n_flat_features))
+    feature_ids = []
+
+    #Assign the power features
+    for roi_idx in range(n_rois):
+        flat_features[:,roi_idx*n_freqs:(roi_idx+1)*n_freqs] = features[:,roi_idx,roi_idx,:]
+        
+        for freq in f:
+            feature_id = f"{rois[roi_idx]} {freq}"
+            feature_ids.append(feature_id)
+    
+    #Assign the directed spectrum causality features
+    flat_idx = n_rois
+    for roi_idx_1 in range(n_rois):
+        for roi_idx_2 in range(n_rois):
+            if roi_idx_1 == roi_idx_2:
+                continue
+            else:
+                start_idx = flat_idx*n_freqs
+                stop_idx = (flat_idx+1)*n_freqs
+                flat_features[:,start_idx:stop_idx] = features[:,roi_idx_1,roi_idx_2,:]
+
+                for freq in f:
+                    feature_id = f"{rois[roi_idx_1]}->{rois[roi_idx_2]} {freq}"
+                    feature_ids.append(feature_id)
+
+
+    return flat_features, feature_ids
 
 def confusion_matrix(true_labels, pred_labels):
     """

--- a/lpne/utils/utils.py
+++ b/lpne/utils/utils.py
@@ -15,15 +15,15 @@ from .. import INVALID_LABEL
 from .data import load_features, save_labels
 
 
-LFP_FN_SUFFIX = '_LFP.mat'
-CHANS_FN_SUFFIX = '_CHANS.mat'
-FEATURE_FN_SUFFIX = '.npy'
-LABEL_FN_SUFFIX = '.npy'
+LFP_FN_SUFFIX = "_LFP.mat"
+CHANS_FN_SUFFIX = "_CHANS.mat"
+FEATURE_FN_SUFFIX = ".npy"
+LABEL_FN_SUFFIX = ".npy"
 
 
-
-def write_fake_labels(feature_dir, label_dir, n_classes=2, label_format='.npy',
-    seed=42):
+def write_fake_labels(
+    feature_dir, label_dir, n_classes=2, label_format=".npy", seed=42
+):
     """
     Write fake behavioral labels.
 
@@ -38,8 +38,8 @@ def write_fake_labels(feature_dir, label_dir, n_classes=2, label_format='.npy',
     # Get filenames.
     feature_fns = get_feature_filenames(feature_dir)
     label_fns = get_label_filenames_from_feature_filenames(
-            feature_fns,
-            label_dir,
+        feature_fns,
+        label_dir,
     )
     # Seed.
     if seed is not None:
@@ -49,7 +49,7 @@ def write_fake_labels(feature_dir, label_dir, n_classes=2, label_format='.npy',
         # Make the appropiate number of labels and save them.
         features = load_features(feature_fn)[0]
         n = len(features)
-        labels = np.random.randint(0,high=n_classes,size=n)
+        labels = np.random.randint(0, high=n_classes, size=n)
         save_labels(labels, label_fn)
     # Undo the seed.
     if seed is not None:
@@ -77,9 +77,9 @@ def get_lfp_filenames(lfp_dir):
     """
     assert os.path.exists(lfp_dir), f"{lfp_dir} doesn't exist!"
     fns = [
-            os.path.join(lfp_dir,fn) \
-            for fn in sorted(os.listdir(lfp_dir)) \
-            if fn.endswith(LFP_FN_SUFFIX)
+        os.path.join(lfp_dir, fn)
+        for fn in sorted(os.listdir(lfp_dir))
+        if fn.endswith(LFP_FN_SUFFIX)
     ]
     if len(fns) == 0:
         warnings.warn(f"No LFP files in {lfp_dir}!")
@@ -102,9 +102,9 @@ def get_feature_filenames(feature_dir):
     """
     assert os.path.exists(feature_dir), f"{feature_dir} doesn't exist!"
     fns = [
-            os.path.join(feature_dir,fn) \
-            for fn in sorted(os.listdir(feature_dir)) \
-            if fn.endswith(FEATURE_FN_SUFFIX)
+        os.path.join(feature_dir, fn)
+        for fn in sorted(os.listdir(feature_dir))
+        if fn.endswith(FEATURE_FN_SUFFIX)
     ]
     if len(fns) == 0:
         warnings.warn(f"No feature files in {feature_dir}!")
@@ -128,8 +128,8 @@ def get_label_filenames_from_feature_filenames(feature_fns, label_dir):
         Label filenames
     """
     return [
-            os.path.join(label_dir, os.path.split(feature_fn)[-1]) \
-            for feature_fn in feature_fns
+        os.path.join(label_dir, os.path.split(feature_fn)[-1])
+        for feature_fn in feature_fns
     ]
 
 
@@ -152,23 +152,23 @@ def get_lfp_chans_filenames(lfp_dir, chans_dir):
     assert os.path.exists(lfp_dir), f"{lfp_dir} doesn't exist!"
     assert os.path.exists(chans_dir), f"{chans_dir} doesn't exist!"
     lfp_fns = [
-            os.path.join(lfp_dir,fn) \
-            for fn in sorted(os.listdir(lfp_dir)) \
-            if fn.endswith(LFP_FN_SUFFIX)
+        os.path.join(lfp_dir, fn)
+        for fn in sorted(os.listdir(lfp_dir))
+        if fn.endswith(LFP_FN_SUFFIX)
     ]
     if len(lfp_fns) == 0:
         warnings.warn(f"No LFP files in {lfp_fns}!")
     chans_fns = [
-            os.path.join(chans_dir,fn) \
-            for fn in sorted(os.listdir(chans_dir)) \
-            if fn.endswith(CHANS_FN_SUFFIX)
+        os.path.join(chans_dir, fn)
+        for fn in sorted(os.listdir(chans_dir))
+        if fn.endswith(CHANS_FN_SUFFIX)
     ]
     if len(chans_fns) == 0:
         warnings.warn(f"No CHANS files in {chans_dir}!")
     assert len(lfp_fns) == len(chans_fns), f"{len(lfp_fns)} != {len(chans_fns)}"
     for i in range(len(lfp_fns)):
-        lfp_fn = os.path.split(lfp_fns[i])[-1][:-len(LFP_FN_SUFFIX)]
-        chans_fn = os.path.split(chans_fns[i])[-1][:-len(CHANS_FN_SUFFIX)]
+        lfp_fn = os.path.split(lfp_fns[i])[-1][: -len(LFP_FN_SUFFIX)]
+        chans_fn = os.path.split(chans_fns[i])[-1][: -len(CHANS_FN_SUFFIX)]
         assert lfp_fn == chans_fn, f"{lfp_fn} != {chans_fn}"
     return lfp_fns, chans_fns
 
@@ -194,21 +194,20 @@ def get_feature_label_filenames(feature_dir, label_dir):
     assert os.path.exists(feature_dir), f"{feature_dir} doesn't exist!"
     assert os.path.exists(label_dir), f"{label_dir} doesn't exist!"
     feature_fns = [
-            os.path.join(feature_dir,fn) \
-            for fn in sorted(os.listdir(feature_dir)) \
-            if fn.endswith(FEATURE_FN_SUFFIX)
+        os.path.join(feature_dir, fn)
+        for fn in sorted(os.listdir(feature_dir))
+        if fn.endswith(FEATURE_FN_SUFFIX)
     ]
     if len(feature_fns) == 0:
         warnings.warn(f"No feature files in {feature_dir}!")
     label_fns = [
-            os.path.join(label_dir,fn) \
-            for fn in sorted(os.listdir(label_dir)) \
-            if fn.endswith(LABEL_FN_SUFFIX)
+        os.path.join(label_dir, fn)
+        for fn in sorted(os.listdir(label_dir))
+        if fn.endswith(LABEL_FN_SUFFIX)
     ]
     if len(label_fns) == 0:
         warnings.warn(f"No label files in {label_dir}!")
-    assert len(feature_fns) == len(label_fns), \
-            f"{len(feature_fns)} != {len(label_fns)}"
+    assert len(feature_fns) == len(label_fns), f"{len(feature_fns)} != {len(label_fns)}"
     for i in range(len(feature_fns)):
         feature_fn = os.path.split(feature_fns[i])[-1]
         label_fn = os.path.split(label_fns[i])[-1]
@@ -248,21 +247,18 @@ def get_weights(labels, groups, invalid_label=INVALID_LABEL):
     if isinstance(groups, torch.Tensor):
         groups = groups.detach().cpu().numpy()
     ids = np.array(labels)
-    idx = np.argwhere( ids == invalid_label).flatten()
+    idx = np.argwhere(ids == invalid_label).flatten()
     idx_comp = np.argwhere(ids != invalid_label).flatten()
     n = len(idx_comp)
     if groups is not None:
-        ids = ids + (np.max(labels)+1) * np.array(groups)
+        ids = ids + (np.max(labels) + 1) * np.array(groups)
     ids_subset = ids[idx_comp]
     unique_ids = np.unique(ids_subset)
-    id_counts = [ \
-            len(np.argwhere(ids_subset==t_id).flatten()) \
-            for t_id in unique_ids \
-    ]
+    id_counts = [len(np.argwhere(ids_subset == t_id).flatten()) for t_id in unique_ids]
     id_weights = n / (len(unique_ids) * np.array(id_counts))
     weights = np.ones(len(labels))
     for id, weight in zip(unique_ids, id_weights):
-        weights[np.argwhere(ids==id).flatten()] = weight
+        weights[np.argwhere(ids == id).flatten()] = weight
     weights[idx] = 1.0
     return weights
 
@@ -282,25 +278,26 @@ def unsqueeze_triangular_array(arr, dim=0):
     new_arr : numpy.ndarray
         Expanded array
     """
-    n = int(round((-1 + np.sqrt(1 + 8*arr.shape[dim])) / 2))
-    assert (n * (n+1)) // 2 == arr.shape[dim], \
-            f"{(n * (n+1)) // 2} != {arr.shape[dim]}"
+    n = int(round((-1 + np.sqrt(1 + 8 * arr.shape[dim])) / 2))
+    assert (n * (n + 1)) // 2 == arr.shape[
+        dim
+    ], f"{(n * (n+1)) // 2} != {arr.shape[dim]}"
     arr = np.swapaxes(arr, dim, -1)
-    new_shape = arr.shape[:-1] + (n,n)
+    new_shape = arr.shape[:-1] + (n, n)
     new_arr = np.zeros(new_shape, dtype=arr.dtype)
     for i in range(n):
-        for j in range(i+1):
-            idx = (i * (i+1)) // 2 + j
+        for j in range(i + 1):
+            idx = (i * (i + 1)) // 2 + j
             new_arr[..., i, j] = arr[..., idx]
             if i != j:
                 new_arr[..., j, i] = arr[..., idx]
-    dim_list = list(range(new_arr.ndim-2)) + [dim]
-    dim_list = dim_list[:dim] + [-2,-1] + dim_list[dim+1:]
+    dim_list = list(range(new_arr.ndim - 2)) + [dim]
+    dim_list = dim_list[:dim] + [-2, -1] + dim_list[dim + 1 :]
     new_arr = np.transpose(new_arr, dim_list)
     return new_arr
 
 
-def squeeze_triangular_array(arr, dims=(0,1)):
+def squeeze_triangular_array(arr, dims=(0, 1)):
     """
     Inverse of `unsqueeze_triangular_array`.
 
@@ -321,15 +318,15 @@ def squeeze_triangular_array(arr, dims=(0,1)):
     assert dims[1] == dims[0] + 1
     n = arr.shape[dims[0]]
     dim_list = list(range(arr.ndim))
-    dim_list = dim_list[:dims[0]] + dim_list[dims[1]+1:] + list(dims)
+    dim_list = dim_list[: dims[0]] + dim_list[dims[1] + 1 :] + list(dims)
     arr = np.transpose(arr, dim_list)
-    new_arr = np.zeros(arr.shape[:-2] + ((n*(n+1))//2,))
+    new_arr = np.zeros(arr.shape[:-2] + ((n * (n + 1)) // 2,))
     for i in range(n):
-        for j in range(i+1):
-            idx = (i * (i+1)) // 2 + j
+        for j in range(i + 1):
+            idx = (i * (i + 1)) // 2 + j
             new_arr[..., idx] = arr[..., i, j]
     dim_list = list(range(new_arr.ndim))
-    dim_list = dim_list[:dims[0]] + [-1] + dim_list[dims[0]:-1]
+    dim_list = dim_list[: dims[0]] + [-1] + dim_list[dims[0] : -1]
     new_arr = np.transpose(new_arr, dim_list)
     return new_arr
 
@@ -337,10 +334,10 @@ def squeeze_triangular_array(arr, dims=(0,1)):
 def get_outlier_summary(lfps, fs, window_duration, top_n=6):
     """
     Return a message summarizing the outliers found
-    
+
     Parameters
     ----------
-    lfps : 
+    lfps :
     fs : int
         Samplerate
     window_duration : float
@@ -370,9 +367,11 @@ def get_outlier_summary(lfps, fs, window_duration, top_n=6):
         if flag:
             window_count += 1
     # Make the message.
-    msg = f"{window_count} of {n_windows} windows contain outliers " \
-          f"({100*window_count/n_windows:.2f}%)\n" \
-          f"Top offending channels:\n"
+    msg = (
+        f"{window_count} of {n_windows} windows contain outliers "
+        f"({100*window_count/n_windows:.2f}%)\n"
+        f"Top offending channels:\n"
+    )
     sorted_counts = np.sort(-roi_counts)
     sorted_rois = np.array(rois)[np.argsort(-roi_counts)]
     for i in range(min(len(rois), top_n)):
@@ -382,7 +381,8 @@ def get_outlier_summary(lfps, fs, window_duration, top_n=6):
         msg += f"  {i+1}) {roi}: {numerator}/{n_windows} ({percent:.2f}%)\n"
     return msg
 
-def flatten_power_features(features,rois,f):
+
+def flatten_power_features(features, rois, f):
     """
     Returns a flattened cross power features congruous with the legacy format
 
@@ -391,7 +391,7 @@ def flatten_power_features(features,rois,f):
     features : numpy.ndarray
         LFP Directed Spectrum Features
         Shape: ``[n_windows,n_freqs,n_roi,n_roi]``
-    
+
     rois : list of str
         Sorted list of ROI labels.
 
@@ -404,13 +404,12 @@ def flatten_power_features(features,rois,f):
         Flattened LFP Directed Spectrum Features sorted by feature type
         Feature Interpretation: ``[n_windows, power features + causality features]``
         Shape: ``[n_windows,n_roi*n_freqs + n_roi*(n_roi-1)*n_freqs]``
-    
+
     feature_ids : list of str
         List mapping flat_features index to a feature label ``<feature_id> <freq>``
         Shape: ``[n_roi*n_freqs + n_roi*(n_roi-1)*n_freqs]
 
     """
-
 
     assert features.shape[-1] == len(rois), f"Shape mismatch between features and rois"
     assert features.shape[1] == len(f), f"Shape mismatch between features and f"
@@ -419,35 +418,40 @@ def flatten_power_features(features,rois,f):
     n_freqs = features.shape[1]
     n_flat_features = n_rois**2 * n_freqs
 
-    flat_features = np.zeros((features.shape[0],n_flat_features))
+    flat_features = np.zeros((features.shape[0], n_flat_features))
     feature_ids = []
 
-    #Assign the power features
+    # Assign the power features
     for roi_idx in range(n_rois):
-        flat_features[:,roi_idx*n_freqs:(roi_idx+1)*n_freqs] = features[:,:,roi_idx,roi_idx]
-        
+        flat_features[:, roi_idx * n_freqs : (roi_idx + 1) * n_freqs] = features[
+            :, :, roi_idx, roi_idx
+        ]
+
         for freq in f:
             feature_id = f"{rois[roi_idx]} {freq}"
             feature_ids.append(feature_id)
-    
-    #Assign the directed spectrum causality features
+
+    # Assign the directed spectrum causality features
     flat_idx = n_rois
     for roi_idx_1 in range(n_rois):
         for roi_idx_2 in range(n_rois):
             if roi_idx_1 == roi_idx_2:
                 continue
             else:
-                start_idx = flat_idx*n_freqs
-                stop_idx = (flat_idx+1)*n_freqs
-                flat_features[:,start_idx:stop_idx] = features[:,:,roi_idx_1,roi_idx_2]
+                start_idx = flat_idx * n_freqs
+                stop_idx = (flat_idx + 1) * n_freqs
+                flat_features[:, start_idx:stop_idx] = features[
+                    :, :, roi_idx_1, roi_idx_2
+                ]
 
                 for freq in f:
                     feature_id = f"{rois[roi_idx_1]}<->{rois[roi_idx_2]} {freq}"
                     feature_ids.append(feature_id)
 
-
     return flat_features, feature_ids
-def flatten_dir_spec_features(features,rois,f):
+
+
+def flatten_dir_spec_features(features, rois, f):
     """
     Returns a flattened directed spectrum congruous with the legacy format.
 
@@ -456,7 +460,7 @@ def flatten_dir_spec_features(features,rois,f):
     features : numpy.ndarray
         LFP Directed Spectrum Features
         Shape: ``[n_windows,n_roi,n_roi,n_freqs]``
-    
+
     rois : list of str
         Sorted list of ROI labels.
 
@@ -469,7 +473,7 @@ def flatten_dir_spec_features(features,rois,f):
         Flattened LFP Directed Spectrum Features sorted by feature type
         Feature Interpretation: ``[n_windows, power features + causality features]``
         Shape: ``[n_windows,n_roi*n_freqs + n_roi*(n_roi-1)*n_freqs]``
-    
+
     feature_ids : list of str
         List mapping flat_features index to a feature label ``<feature_id> <freq>``
         Shape: ``[n_roi*n_freqs + n_roi*(n_roi-1)*n_freqs]
@@ -482,34 +486,38 @@ def flatten_dir_spec_features(features,rois,f):
     n_freqs = features.shape[-1]
     n_flat_features = n_rois**2 * n_freqs
 
-    flat_features = np.zeros((features.shape[0],n_flat_features))
+    flat_features = np.zeros((features.shape[0], n_flat_features))
     feature_ids = []
 
-    #Assign the power features
+    # Assign the power features
     for roi_idx in range(n_rois):
-        flat_features[:,roi_idx*n_freqs:(roi_idx+1)*n_freqs] = features[:,roi_idx,roi_idx,:]
-        
+        flat_features[:, roi_idx * n_freqs : (roi_idx + 1) * n_freqs] = features[
+            :, roi_idx, roi_idx, :
+        ]
+
         for freq in f:
             feature_id = f"{rois[roi_idx]} {freq}"
             feature_ids.append(feature_id)
-    
-    #Assign the directed spectrum causality features
+
+    # Assign the directed spectrum causality features
     flat_idx = n_rois
     for roi_idx_1 in range(n_rois):
         for roi_idx_2 in range(n_rois):
             if roi_idx_1 == roi_idx_2:
                 continue
             else:
-                start_idx = flat_idx*n_freqs
-                stop_idx = (flat_idx+1)*n_freqs
-                flat_features[:,start_idx:stop_idx] = features[:,roi_idx_1,roi_idx_2,:]
+                start_idx = flat_idx * n_freqs
+                stop_idx = (flat_idx + 1) * n_freqs
+                flat_features[:, start_idx:stop_idx] = features[
+                    :, roi_idx_1, roi_idx_2, :
+                ]
 
                 for freq in f:
                     feature_id = f"{rois[roi_idx_1]}->{rois[roi_idx_2]} {freq}"
                     feature_ids.append(feature_id)
 
-
     return flat_features, feature_ids
+
 
 def confusion_matrix(true_labels, pred_labels):
     """
@@ -517,7 +525,7 @@ def confusion_matrix(true_labels, pred_labels):
 
     This is a wrapper around ``sklearn.metrics.confusion_matrix`` that
     disregards ``lpne.INVALID_LABEL``.
-    
+
     Parameters
     ----------
     true_labels : numpy.ndarray
@@ -538,10 +546,8 @@ def confusion_matrix(true_labels, pred_labels):
     return sk_confusion_matrix(true_labels[idx], pred_labels[idx])
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/lpne/utils/utils.py
+++ b/lpne/utils/utils.py
@@ -442,7 +442,7 @@ def flatten_power_features(features,rois,f):
                 flat_features[:,start_idx:stop_idx] = features[:,:,roi_idx_1,roi_idx_2]
 
                 for freq in f:
-                    feature_id = f"{rois[roi_idx_1]}->{rois[roi_idx_2]} {freq}"
+                    feature_id = f"{rois[roi_idx_1]}<->{rois[roi_idx_2]} {freq}"
                     feature_ids.append(feature_id)
 
 

--- a/lpne/utils/viterbi.py
+++ b/lpne/utils/viterbi.py
@@ -14,7 +14,6 @@ import torch
 MIN_LOG_EMISSION = -50.0
 
 
-
 def top_k_viterbi(emissions, transition_mat, top_k=10):
     """
     A top-K Viterbi decoder.
@@ -40,7 +39,7 @@ def top_k_viterbi(emissions, transition_mat, top_k=10):
     # Handle NaNs in the emissions.
     emissions[np.isnan(emissions)] = 1 / emissions.shape[1]
     # Convert to logspace and torch Tensors.
-    tag_sequence = torch.tensor(np.maximum(np.log(emissions),MIN_LOG_EMISSION))
+    tag_sequence = torch.tensor(np.maximum(np.log(emissions), MIN_LOG_EMISSION))
     transition_matrix = torch.tensor(np.log(transition_mat))
     sequence_length, num_tags = list(tag_sequence.size())
     path_scores = []
@@ -51,7 +50,7 @@ def top_k_viterbi(emissions, transition_mat, top_k=10):
     # Evaluate the scores for all possible paths.
     for t in range(1, sequence_length):
         # Add pairwise potentials to current scores.
-        summed_potentials = path_scores[t-1].unsqueeze(2) + transition_matrix
+        summed_potentials = path_scores[t - 1].unsqueeze(2) + transition_matrix
         summed_potentials = summed_potentials.view(-1, num_tags)
         # Best pairwise potential path score from the previous timestep.
         max_k = min(summed_potentials.size()[0], top_k)
@@ -101,7 +100,7 @@ def get_label_stats(viterbi_paths, viterbi_scores, n_classes):
         Shape: ``[n_classes, n_classes]``
     """
     if viterbi_paths.ndim == 1:
-        viterbi_paths = viterbi_paths.reshape(1,-1)
+        viterbi_paths = viterbi_paths.reshape(1, -1)
         viterbi_scores = np.zeros(1)
     # Calculate stats for each label sequence.
     bout_counts, bout_durations, trans_counts = [], [], []
@@ -113,10 +112,10 @@ def get_label_stats(viterbi_paths, viterbi_scores, n_classes):
     # Average the results.
     scores = np.exp(viterbi_scores - np.max(viterbi_scores))
     scores /= np.sum(scores)
-    scores = scores.reshape(-1,1)
+    scores = scores.reshape(-1, 1)
     bout_counts = (np.vstack(bout_counts) * scores).sum(axis=0)
     bout_durations = (np.vstack(bout_durations) * scores).sum(axis=0)
-    scores = scores.reshape(-1,1,1)
+    scores = scores.reshape(-1, 1, 1)
     transitions = (np.vstack(transitions) * scores).sum(axis=0)
     # Return stats.
     return bout_counts, bout_durations, transitions
@@ -129,26 +128,24 @@ def _bout_info(seq, n_classes):
     # First window
     bout_counts[seq[0]] = 1.0
     bout_duration[seq[0]] = 1.0
-    for i in range(1,len(seq)):
-        if seq[i] != seq[i-1]:
+    for i in range(1, len(seq)):
+        if seq[i] != seq[i - 1]:
             bout_counts[seq[i]] += 1.0
         bout_duration[seq[i]] += 1.0
-    return bout_counts, bout_duration/bout_counts
+    return bout_counts, bout_duration / bout_counts
 
 
 def _transition_info(seq, n_classes):
     """Return the transition count matrix."""
     mat = np.zeros((n_classes, n_classes))
     for i in range(1, len(seq)):
-        if seq[i] != seq[i-1]:
-            mat[seq[i-1],seq[i]] += 1.0
+        if seq[i] != seq[i - 1]:
+            mat[seq[i - 1], seq[i]] += 1.0
     return mat
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/test/test_channel_maps.py
+++ b/test/test_channel_maps.py
@@ -11,8 +11,7 @@ import pytest
 import lpne
 
 
-FAKE_ROIS = ['foo_L_01', 'foo_R_02', 'bar_L_01', 'bar_L_02']
-
+FAKE_ROIS = ["foo_L_01", "foo_R_02", "bar_L_01", "bar_L_02"]
 
 
 def test_get_default_channel_map_1():
@@ -56,14 +55,12 @@ def _get_fake_lfps():
 def _get_fake_channel_map():
     channel_map = {}
     for roi in _get_fake_rois():
-        channel_map[roi] = roi.split('_')[0]
+        channel_map[roi] = roi.split("_")[0]
     return channel_map
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -10,23 +10,20 @@ import pytest
 import lpne
 
 
-
 def test_load_lfps_1():
     """Make sure lpne.load_lfp throws an error for non-existing filename."""
     with pytest.raises(FileNotFoundError):
-        x = lpne.load_lfps('not_a_real_lfp_filename.mat')
+        x = lpne.load_lfps("not_a_real_lfp_filename.mat")
 
 
 def test_load_lfps_2():
     """Make sure lpne.load_lfp throws an error for non-supported file type."""
     with pytest.raises(NotImplementedError):
-        x = lpne.load_lfps('possibly_a_real_lfp_filename.npy')
+        x = lpne.load_lfps("possibly_a_real_lfp_filename.npy")
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/test/test_make_features.py
+++ b/test/test_make_features.py
@@ -10,40 +10,40 @@ import numpy as np
 import lpne
 
 
-
 def test_make_features_1():
     """Make sure the features have the correct shapes."""
     # Define constants.
     n_samples = 1000
     fs = 1000
     window_duration = 1.0
-    for n_rois in [1,2,5]:
+    for n_rois in [1, 2, 5]:
         # Make fake LFPs.
         lfps = {}
         for i in range(n_rois):
-            lfps[f'roi_{i}'] = np.random.randn(n_samples)
+            lfps[f"roi_{i}"] = np.random.randn(n_samples)
         # Make features.
         res = lpne.make_features(
-                lfps,
-                fs=fs,
-                window_duration=window_duration,
+            lfps,
+            fs=fs,
+            window_duration=window_duration,
         )
-        assert 'power' in res
-        assert 'freq' in res
-        assert 'rois' in res
+        assert "power" in res
+        assert "freq" in res
+        assert "rois" in res
         n_window = int(np.ceil(window_duration * n_samples / fs))
-        roi_pairs = (n_rois * (n_rois+1)) // 2
-        assert res['power'].shape[:2] == (n_window,roi_pairs), \
-                f"{res['power'].shape}, ({n_window},{roi_pairs})"
-        assert len(res['freq'] == res['power'].shape[2]), \
-                "Inconsistent numbers of frequencies!"
-        assert len(res['rois']) == n_rois, "Incorrect number of ROIs!"
+        roi_pairs = (n_rois * (n_rois + 1)) // 2
+        assert res["power"].shape[:2] == (
+            n_window,
+            roi_pairs,
+        ), f"{res['power'].shape}, ({n_window},{roi_pairs})"
+        assert len(
+            res["freq"] == res["power"].shape[2]
+        ), "Inconsistent numbers of frequencies!"
+        assert len(res["rois"]) == n_rois, "Incorrect number of ROIs!"
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -12,7 +12,6 @@ import pytest
 from lpne.models import FaSae, CpSae
 
 
-
 def test_factor_analysis_sae():
     """Make some fake data, train briefly, and reload the model."""
     b, f, r, g = 10, 9, 8, 2
@@ -26,9 +25,9 @@ def test_factor_analysis_sae():
     for nonnegative, variational in product(nmf_vals, variational_vals):
         # Make the model.
         model = FaSae(
-                nonnegative=nonnegative,
-                variational=variational,
-                n_iter=1,
+            nonnegative=nonnegative,
+            variational=variational,
+            n_iter=1,
         )
         # Fit the model.
         model.fit(features, labels, groups, print_freq=None)
@@ -36,9 +35,9 @@ def test_factor_analysis_sae():
         _ = model.predict(features, groups)
         # Calculate a weighted accuracy.
         weighted_acc_orig = model.score(
-                features,
-                labels,
-                groups,
+            features,
+            labels,
+            groups,
         )
         # Get state.
         params = model.get_params()
@@ -47,9 +46,9 @@ def test_factor_analysis_sae():
         new_model.set_params(**params)
         # Calculate a weighted accuracy.
         weighted_acc = new_model.score(
-                features,
-                labels,
-                groups,
+            features,
+            labels,
+            groups,
         )
         assert weighted_acc_orig == weighted_acc
 
@@ -65,9 +64,9 @@ def test_cp_sae():
     _ = model.predict(features, groups)
     # Calculate a weighted accuracy.
     weighted_acc_orig = model.score(
-            features,
-            labels,
-            groups,
+        features,
+        labels,
+        groups,
     )
     # Get state.
     params = model.get_params()
@@ -76,17 +75,15 @@ def test_cp_sae():
     new_model.set_params(**params)
     # Calculate a weighted accuracy.
     weighted_acc = new_model.score(
-            features,
-            labels,
-            groups,
+        features,
+        labels,
+        groups,
     )
     assert weighted_acc_orig == weighted_acc
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -8,77 +8,74 @@ import numpy as np
 import lpne
 
 
-
 def test_unsqueeze_triangular_array():
     # Shape 1
-    arr = np.random.randn(3,10,8)
+    arr = np.random.randn(3, 10, 8)
     new_arr = lpne.unsqueeze_triangular_array(arr, dim=1)
-    assert new_arr.shape == (3,4,4,8)
+    assert new_arr.shape == (3, 4, 4, 8)
     residual = new_arr - np.transpose(new_arr, [0, 2, 1, 3])
     assert np.allclose(residual, np.zeros_like(residual))
     # Shape 2
-    arr = np.random.randn(10,8)
+    arr = np.random.randn(10, 8)
     new_arr = lpne.unsqueeze_triangular_array(arr, dim=0)
-    assert new_arr.shape == (4,4,8)
+    assert new_arr.shape == (4, 4, 8)
     residual = new_arr - np.swapaxes(new_arr, 0, 1)
     assert np.allclose(residual, np.zeros_like(residual))
     # Shape 3
-    arr = np.random.randn(3,10)
+    arr = np.random.randn(3, 10)
     new_arr = lpne.unsqueeze_triangular_array(arr, dim=1)
-    assert new_arr.shape == (3,4,4)
+    assert new_arr.shape == (3, 4, 4)
     residual = new_arr - np.swapaxes(new_arr, 1, 2)
     assert np.allclose(residual, np.zeros_like(residual))
 
 
 def test_squeeze_triangular_array():
     # Shape 1
-    arr = np.random.randn(3,4,4,8)
-    new_arr = lpne.squeeze_triangular_array(arr, dims=(1,2))
-    assert new_arr.shape == (3,10,8)
+    arr = np.random.randn(3, 4, 4, 8)
+    new_arr = lpne.squeeze_triangular_array(arr, dims=(1, 2))
+    assert new_arr.shape == (3, 10, 8)
     # Shape 2
-    arr = np.random.randn(4,4,8)
-    new_arr = lpne.squeeze_triangular_array(arr, dims=(0,1))
-    assert new_arr.shape == (10,8)
+    arr = np.random.randn(4, 4, 8)
+    new_arr = lpne.squeeze_triangular_array(arr, dims=(0, 1))
+    assert new_arr.shape == (10, 8)
     # Shape 3
-    arr = np.random.randn(3,4,4)
-    new_arr = lpne.squeeze_triangular_array(arr, dims=(1,2))
-    assert new_arr.shape == (3,10)
+    arr = np.random.randn(3, 4, 4)
+    new_arr = lpne.squeeze_triangular_array(arr, dims=(1, 2))
+    assert new_arr.shape == (3, 10)
 
 
 def test_squeeze_unsqeeuze_triangular_array():
-    arr_1 = np.random.randn(3,4,4,8)
-    arr_1 = arr_1 + np.transpose(arr_1, [0,2,1,3])
-    arr_2 = lpne.squeeze_triangular_array(arr_1, dims=(1,2))
+    arr_1 = np.random.randn(3, 4, 4, 8)
+    arr_1 = arr_1 + np.transpose(arr_1, [0, 2, 1, 3])
+    arr_2 = lpne.squeeze_triangular_array(arr_1, dims=(1, 2))
     arr_3 = lpne.unsqueeze_triangular_array(arr_2, dim=1)
-    arr_4 = lpne.squeeze_triangular_array(arr_3, dims=(1,2))
+    arr_4 = lpne.squeeze_triangular_array(arr_3, dims=(1, 2))
     assert np.allclose(arr_1, arr_3)
     assert np.allclose(arr_2, arr_4)
 
 
 def test_get_weights_1():
-    labels = np.array([0,0,1,0,1], dtype=int)
-    groups = np.array([0,0,0,1,1], dtype=int)
+    labels = np.array([0, 0, 1, 0, 1], dtype=int)
+    groups = np.array([0, 0, 0, 1, 1], dtype=int)
     weights = lpne.get_weights(labels, groups)
     assert np.mean(weights) == 1.0
     assert np.sum(weights[:3]) == np.sum(weights[3:])
-    assert np.allclose(weights / weights[0], np.array([1,1,2,2,2]))
+    assert np.allclose(weights / weights[0], np.array([1, 1, 2, 2, 2]))
 
 
 def test_get_weights_2():
-    labels = np.array([0,0,1,0,1,-1,-1], dtype=int)
-    groups = np.array([0,0,0,1,1,0,1], dtype=int)
+    labels = np.array([0, 0, 1, 0, 1, -1, -1], dtype=int)
+    groups = np.array([0, 0, 0, 1, 1, 0, 1], dtype=int)
     weights = lpne.get_weights(labels, groups, invalid_label=-1)
     print(weights)
     assert np.mean(weights) == 1.0
     assert np.sum(weights[:3]) == np.sum(weights[3:5])
-    assert np.allclose(weights[:5] / weights[0], np.array([1,1,2,2,2]))
+    assert np.allclose(weights[:5] / weights[0], np.array([1, 1, 2, 2, 2]))
     assert np.allclose(weights[-2:], np.ones(2))
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
-
 
 
 ###

--- a/test/test_viterbi.py
+++ b/test/test_viterbi.py
@@ -9,14 +9,13 @@ import numpy as np
 import lpne
 
 
-
 def test_viterbi_1():
     """Make sure Viterbi returns MLE with uninformative transitions."""
-    T, K, N  = 3, 2, 5
-    transition_mat = np.ones((K,K))
+    T, K, N = 3, 2, 5
+    transition_mat = np.ones((K, K))
     transition_mat /= np.sum(transition_mat, axis=1, keepdims=True)
     for test_num in range(N):
-        emissions = np.random.rand(T,K)
+        emissions = np.random.rand(T, K)
         emissions /= np.sum(emissions, axis=1, keepdims=True)
         true_seq = np.argmax(emissions, axis=1)
         pred_seqs, _ = lpne.top_k_viterbi(emissions, transition_mat)
@@ -25,22 +24,22 @@ def test_viterbi_1():
 
 def test_viterbi_3():
     """Make sure Viterbi respects a forbidden transition."""
-    T, K, N  = 10, 3, 50
+    T, K, N = 10, 3, 50
     for test_num in range(N):
-        transition_mat = np.random.rand(K,K) + 1e-6
-        transition_mat[0,1] = 0.0 # Can't go from state 0 to state 1.
+        transition_mat = np.random.rand(K, K) + 1e-6
+        transition_mat[0, 1] = 0.0  # Can't go from state 0 to state 1.
         transition_mat /= np.sum(transition_mat, axis=1, keepdims=True)
-        emissions = np.random.rand(T,K)
+        emissions = np.random.rand(T, K)
         emissions /= np.sum(emissions, axis=1, keepdims=True)
         pred_seqs, _ = lpne.top_k_viterbi(emissions, transition_mat)
         for k in range(pred_seqs.shape[0]):
-            for i in range(T-1):
-                assert pred_seqs[k,i] != 0 or pred_seqs[k,i+1] != 1, \
-                        f"{pred_seqs[k]}"
+            for i in range(T - 1):
+                assert (
+                    pred_seqs[k, i] != 0 or pred_seqs[k, i + 1] != 1
+                ), f"{pred_seqs[k]}"
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass
 
 


### PR DESCRIPTION
I created nmf_base_class as a flexible base for NMF decoder models with our usual constraints on the reconstruction losses for the supervised networks. These models have been tested on old format lpne data. Updated tools and GUI integration will be finished once the TST data has been processed.

I also created a flatten_power_features and flatten_dir_spec_features function in utils that will convert the data format [n_samples, freqs, n_roi,n_roi] and [n_samples,n_roi,n_roi,n_freqs] to the old format of [n_samples,n_features] respectively. Both also return a feature label list that includes `<roi> <freq>` labels for power or within roi features, `<roi1> -> <roi2> <freq>` features for causality features, and `<roi1> <-> <roi2> <freq>` labels for paired features like cross power.